### PR TITLE
fix: scoring/output follow-ups + stop ligand recentering

### DIFF
--- a/matcha/cli.py
+++ b/matcha/cli.py
@@ -383,7 +383,7 @@ def run_matcha(
     scorer_type: str = typer.Option("gnina", "--scorer", help="Pose scorer: gnina, custom, or none."),
     scorer_path: Optional[Path] = typer.Option(None, "--scorer-path", help="Path to gnina binary or custom scorer script."),
     scorer_minimize: bool = typer.Option(True, "--scorer-minimize/--no-scorer-minimize", help="Minimize poses during scoring (gnina)."),
-    gnina_batch_mode: str = typer.Option("combined", "--gnina-batch-mode", help="GNINA batch mode: combined or per-ligand (batch mode only)."),
+    gnina_batch_mode: str = typer.Option("per-ligand", "--gnina-batch-mode", help="GNINA scoring mode for batch runs (currently only per-ligand)."),
     physical_only: bool = typer.Option(False, "--physical-only/--keep-all-poses", help="Keep only PoseBusters-passing poses in outputs (default: False)."),
 ) -> None:
     if out is None:
@@ -699,9 +699,6 @@ def run_matcha(
     scorer_used = False
     sdf_scored = preds_root / dataset_name / "minimized_sdf_predictions"
     best_scored_dir = preds_root / dataset_name / "best_minimized_predictions"
-    if scorer_type != "none" and scorer_type.startswith("gnina") and not resolved_device.startswith("cuda"):
-        console.print(f"[bold yellow][matcha][/bold yellow] GNINA requires CUDA; skipping scoring on {resolved_device}")
-        scorer_type = "none"
     if scorer_type != "none":
         scoring_start = time.perf_counter()
         try:
@@ -710,26 +707,12 @@ def run_matcha(
             sdf_input = preds_root / dataset_name / "sdf_predictions"
             filters_path = preds_root / dataset_name / "filters_results_minimized.json"
             if scorer_type.startswith("gnina") and batch_mode:
-                if gnina_batch_mode not in {"combined", "per-ligand"}:
-                    raise typer.BadParameter("--gnina-batch-mode must be 'combined' or 'per-ligand'")
-            if scorer_type.startswith("gnina") and batch_mode and gnina_batch_mode == "combined":
-                scorer.score_poses_combined(
-                    str(receptor), str(sdf_input),
-                    str(sdf_scored), str(best_scored_dir),
-                    filters_path=str(filters_path),
-                    n_samples=n_samples,
-                    device=cuda_device_idx,
-                )
-                compute_fast_filters_from_sdf(conf, run_name, sdf_type='minimized', n_preds_to_use=n_samples)
-                scorer.select_top_poses(
-                    str(sdf_scored), str(best_scored_dir),
-                    filters_path=str(filters_path), n_samples=n_samples
-                )
-            else:
-                scorer.score_poses(str(receptor), str(sdf_input), str(sdf_scored), device=cuda_device_idx)
-                compute_fast_filters_from_sdf(conf, run_name, sdf_type='minimized', n_preds_to_use=n_samples)
-                scorer.select_top_poses(str(sdf_scored), str(best_scored_dir),
-                                        filters_path=str(filters_path), n_samples=n_samples)
+                if gnina_batch_mode != "per-ligand":
+                    raise typer.BadParameter("--gnina-batch-mode currently supports only 'per-ligand'")
+            scorer.score_poses(str(receptor), str(sdf_input), str(sdf_scored), device=cuda_device_idx)
+            compute_fast_filters_from_sdf(conf, run_name, sdf_type='minimized', n_preds_to_use=n_samples)
+            scorer.select_top_poses(str(sdf_scored), str(best_scored_dir),
+                                    filters_path=str(filters_path), n_samples=n_samples)
             scorer_used = True
             console.print(f"[bold green][matcha][/bold green] scoring complete ({scorer.name})")
         except RuntimeError as e:

--- a/matcha/cli.py
+++ b/matcha/cli.py
@@ -341,7 +341,6 @@ def _print_usage_and_exit() -> None:
 
 [bold]Options:[/bold]
   -g, --device TEXT        Device: auto, cpu, cuda, cuda:N, mps
-  --n-samples INT         Poses per ligand (default: 20)
   --gpus TEXT              Multi-GPU ids for batch mode, e.g. 2,3
   --n-samples INT          Poses per ligand (default: 20)
   --scorer TEXT            gnina / custom / none (default: gnina)
@@ -700,6 +699,9 @@ def run_matcha(
     scorer_used = False
     sdf_scored = preds_root / dataset_name / "minimized_sdf_predictions"
     best_scored_dir = preds_root / dataset_name / "best_minimized_predictions"
+    if scorer_type != "none" and scorer_type.startswith("gnina") and not resolved_device.startswith("cuda"):
+        console.print(f"[bold yellow][matcha][/bold yellow] GNINA requires CUDA; skipping scoring on {resolved_device}")
+        scorer_type = "none"
     if scorer_type != "none":
         scoring_start = time.perf_counter()
         try:
@@ -707,10 +709,27 @@ def run_matcha(
                                    minimize=scorer_minimize)
             sdf_input = preds_root / dataset_name / "sdf_predictions"
             filters_path = preds_root / dataset_name / "filters_results_minimized.json"
-            scorer.score_poses(str(receptor), str(sdf_input), str(sdf_scored), device=cuda_device_idx)
-            compute_fast_filters_from_sdf(conf, run_name, sdf_type='minimized', n_preds_to_use=n_samples)
-            scorer.select_top_poses(str(sdf_scored), str(best_scored_dir),
-                                    filters_path=str(filters_path), n_samples=n_samples)
+            if scorer_type.startswith("gnina") and batch_mode:
+                if gnina_batch_mode not in {"combined", "per-ligand"}:
+                    raise typer.BadParameter("--gnina-batch-mode must be 'combined' or 'per-ligand'")
+            if scorer_type.startswith("gnina") and batch_mode and gnina_batch_mode == "combined":
+                scorer.score_poses_combined(
+                    str(receptor), str(sdf_input),
+                    str(sdf_scored), str(best_scored_dir),
+                    filters_path=str(filters_path),
+                    n_samples=n_samples,
+                    device=cuda_device_idx,
+                )
+                compute_fast_filters_from_sdf(conf, run_name, sdf_type='minimized', n_preds_to_use=n_samples)
+                scorer.select_top_poses(
+                    str(sdf_scored), str(best_scored_dir),
+                    filters_path=str(filters_path), n_samples=n_samples
+                )
+            else:
+                scorer.score_poses(str(receptor), str(sdf_input), str(sdf_scored), device=cuda_device_idx)
+                compute_fast_filters_from_sdf(conf, run_name, sdf_type='minimized', n_preds_to_use=n_samples)
+                scorer.select_top_poses(str(sdf_scored), str(best_scored_dir),
+                                        filters_path=str(filters_path), n_samples=n_samples)
             scorer_used = True
             console.print(f"[bold green][matcha][/bold green] scoring complete ({scorer.name})")
         except RuntimeError as e:

--- a/tests/test_cli_reproducibility.py
+++ b/tests/test_cli_reproducibility.py
@@ -215,7 +215,7 @@ def _run_local_cli_repro_case(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, r
         scorer_type="custom",
         scorer_path=fake_scorer_script,
         scorer_minimize=True,
-        gnina_batch_mode="combined",
+        gnina_batch_mode="per-ligand",
         physical_only=False,
         num_dataloader_workers=0,
     )
@@ -313,7 +313,7 @@ def test_run_matcha_overwrite_retries_directory_not_empty(
         scorer_type="custom",
         scorer_path=fake_scorer_script,
         scorer_minimize=True,
-        gnina_batch_mode="combined",
+        gnina_batch_mode="per-ligand",
         physical_only=False,
         num_dataloader_workers=0,
     )

--- a/tests/test_multigpu_cmd_build.py
+++ b/tests/test_multigpu_cmd_build.py
@@ -27,7 +27,7 @@ def test_build_shard_command_contains_required_gpu_flags():
         scorer_type="gnina",
         scorer_path=None,
         scorer_minimize=True,
-        gnina_batch_mode="combined",
+        gnina_batch_mode="per-ligand",
         physical_only=False,
     )
 


### PR DESCRIPTION
Supersedes #21.

## What
- finalize scoring/output correctness follow-ups on top of PR5
- align minimized scoring flow with the already accepted CLI logic from earlier PRs
- stop ligand recentering during dataset preparation

## Main changes
- `matcha/cli.py`
  - use minimized scoring output directories consistently
  - recompute fast PoseBusters filters from minimized SDFs before top-pose selection
  - keep scoring/output selection logic aligned with the accepted CLI behavior
- `matcha/dataset/pdbbind.py`
  - remove ligand recentering during dataset preparation
  - preserve Dasha's small CLI/data fix already included in this branch

## Why
This PR is intentionally small and functional: it makes scoring outputs consistent with the minimized flow and removes ligand recentering, which is no longer needed and should not affect current logic.

## Validation
```bash
uv run pytest -n0 tests
```

Manual run shape to verify minimized scoring flow:
```bash
CUDA_VISIBLE_DEVICES=7 uv run matcha \
  -r /mnt/ligandpro/db/datasets/posebusters/astex_diverse_set/1N1M_A3M/1N1M_A3M_protein.pdb \
  -l /mnt/ligandpro/db/datasets/posebusters/astex_diverse_set/1N1M_A3M/1N1M_A3M_ligand_start_conf.sdf \
  --run-name pr6_scoring_validation \
  --overwrite \
  -o output \
  --scorer-path /mnt/ligandpro/soft/docking/gnina/run_gnina.sh
```