### PR TITLE
feat(conformers): isolated nvMolKit worker backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,8 @@ celerybeat.pid
 .env
 .envrc
 .venv
+# Matcha: isolated nvMolKit conformer worker env
+.venv-nvmolkit-worker/
 env/
 venv/
 ENV/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,54 @@ Or with pip:
 pip install -e .
 ```
 
+### Optional: isolated GPU conformer worker backend (nvMolKit)
+
+Matcha can offload conformer generation to an isolated GPU worker process based on NVIDIA nvMolKit. This keeps the main Matcha environment unchanged and avoids ABI/runtime conflicts.
+
+Runtime toggles (no CLI flags):
+- `MATCHA_CONFORMER_BACKEND=auto|rdkit|worker` (default: `auto`)
+- `MATCHA_CONFORMER_WORKER_CMD` (optional; overrides auto-discovery)
+- `MATCHA_CONFORMER_WORKER_TIMEOUT_SEC` (default: `300`)
+- `MATCHA_CONFORMER_WORKER_CHUNK_SIZE` (default: `128`)
+
+Auto-discovery:
+- If `.venv-nvmolkit-worker/bin/matcha-nvmolkit-worker` exists in the repository root, Matcha will use it automatically.
+- Legacy fallback is kept for compatibility: `.venv-nvmolkit-worker/bin/python scripts/nvmolkit_worker.py`.
+
+Auto-setup & download (recommended):
+
+```bash
+# Linux + NVIDIA GPU. Creates .venv-nvmolkit-worker/ and runs an end-to-end smoke test.
+uv run python scripts/setup_nvmolkit_worker.py
+```
+
+This script may download:
+- nvMolKit source from GitHub (`NVIDIA-Digital-Bio/nvMolKit`)
+- CUDA toolkit components from NVIDIA's CUDA repo (Ubuntu 24.04 only; user-space extract, no sudo)
+
+Verify the worker is ready:
+
+```bash
+# The setup script should end with:
+# [ok] worker smoke: ...
+# [ok] nvMolKit worker env is ready.
+
+# Optional: verify Matcha can invoke the worker (fail-fast if missing/broken)
+MATCHA_CONFORMER_BACKEND=worker uv run python - <<'PY'
+from rdkit import Chem
+from matcha.utils.preprocessing import generate_conformer_mols_batch
+
+out = generate_conformer_mols_batch([Chem.MolFromSmiles("CCO")], confs_per_mol=2)
+assert len(out) == 1 and len(out[0]) == 2
+print("ok: conformer worker")
+PY
+```
+
+Backend behavior:
+- `MATCHA_CONFORMER_BACKEND=auto`: use the worker when available; if it fails, fall back to RDKit.
+- `MATCHA_CONFORMER_BACKEND=worker`: require the worker (errors if missing or failing).
+- `MATCHA_CONFORMER_BACKEND=rdkit`: always use RDKit (no worker).
+
 ## CLI usage <a name="cli"></a>
 
 The `matcha` CLI wraps the full inference pipeline (ESM embeddings, 3-stage docking, PoseBusters filtering) with GNINA minimization and scoring into a single command.

--- a/matcha/dataset/pdbbind.py
+++ b/matcha/dataset/pdbbind.py
@@ -377,13 +377,20 @@ class PDBBind(Dataset):
 
         self.predicted_ligand_transforms = np.load(
             predicted_ligand_transforms_path, allow_pickle=True)[0]
+        missing_predictions = sum(
+            1
+            for c in self.complexes
+            if c.name in self.predicted_ligand_transforms
+            and len(self.predicted_ligand_transforms[c.name]) == 0
+        )
         self.complexes = [
-            c for c in self.complexes if c.name in self.predicted_ligand_transforms]
+            c for c in self.complexes
+            if c.name in self.predicted_ligand_transforms
+            and len(self.predicted_ligand_transforms[c.name]) > 0
+        ]
         if not self.complexes:
             raise ValueError(
                 f"No complexes found in predicted transforms from {predicted_ligand_transforms_path}")
-        n_preds_to_use_real = min(n_preds_to_use, len(
-            self.predicted_ligand_transforms[self.complexes[0].name]))
 
         # initialize extended complexes
         extended_complexes = []
@@ -392,6 +399,8 @@ class PDBBind(Dataset):
             if complex.name in processed_names:
                 continue
             processed_names.add(complex.name)
+            pred_transforms = self.predicted_ligand_transforms[complex.name]
+            n_preds_to_use_real = min(n_preds_to_use, len(pred_transforms))
             for i in range(n_preds_to_use_real):
                 # Avoid copying the (large) protein object for every sample.
                 # This significantly reduces CPU memory use for batched inference
@@ -402,7 +411,7 @@ class PDBBind(Dataset):
                     protein=complex.protein,
                     original_augm_rot=complex.original_augm_rot,
                 )
-                pred_data = self.predicted_ligand_transforms[complex.name][i]
+                pred_data = pred_transforms[i]
                 extended_complex.ligand.pred_tr = pred_data['tr_pred_init'] + \
                     pred_data['full_protein_center'] - \
                     extended_complex.protein.full_protein_center
@@ -415,6 +424,12 @@ class PDBBind(Dataset):
                     extended_complex.ligand.predicted_pos = pred_pos.astype(np.float32)
 
                 extended_complexes.append(extended_complex)
+        if missing_predictions > 0:
+            logger.warning(
+                "Skipping %d complexes without predicted ligand transforms from %s",
+                missing_predictions,
+                predicted_ligand_transforms_path,
+            )
         self.complexes = extended_complexes
 
     def __len__(self):

--- a/matcha/utils/preprocessing.py
+++ b/matcha/utils/preprocessing.py
@@ -7,6 +7,8 @@ import subprocess
 import tempfile
 import threading
 import time
+from contextlib import contextmanager
+import fcntl
 from queue import Queue
 from pathlib import Path
 
@@ -283,21 +285,30 @@ def _env_flag(name: str, default: bool) -> bool:
     return default
 
 
+@contextmanager
+def _worker_setup_file_lock(lock_path: Path):
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a+", encoding="utf-8") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
+
 def _auto_setup_worker_once() -> bool:
     global _WORKER_AUTO_SETUP_ATTEMPTED, _WORKER_AUTO_SETUP_SUCCEEDED
 
     with _WORKER_AUTO_SETUP_LOCK:
         if _WORKER_AUTO_SETUP_SUCCEEDED:
             return True
-        if _WORKER_AUTO_SETUP_ATTEMPTED:
-            return False
-        _WORKER_AUTO_SETUP_ATTEMPTED = True
 
         if not _env_flag("MATCHA_CONFORMER_AUTO_SETUP_WORKER", True):
             logger.info("Conformer worker auto-setup is disabled by MATCHA_CONFORMER_AUTO_SETUP_WORKER")
             return False
 
         repo_root = Path(__file__).resolve().parents[2]
+        worker_lock_path = repo_root / ".venv-nvmolkit-worker.setup.lock"
         setup_script = repo_root / "scripts" / "setup_nvmolkit_worker.py"
         if not setup_script.exists():
             logger.warning(f"Worker setup script not found: {setup_script}")
@@ -307,49 +318,57 @@ def _auto_setup_worker_once() -> bool:
             logger.warning("Cannot auto-setup conformer worker because `uv` is not in PATH")
             return False
 
-        setup_timeout_sec = _get_env_int("MATCHA_CONFORMER_WORKER_SETUP_TIMEOUT_SEC", 3600)
-        cmd = ["uv", "run", "python", str(setup_script), "--skip-smoke"]
-        logger.info(
-            "Conformer worker is not installed; running automatic setup "
-            "(set MATCHA_CONFORMER_AUTO_SETUP_WORKER=0 to disable)"
-        )
+        with _worker_setup_file_lock(worker_lock_path):
+            if _WORKER_AUTO_SETUP_SUCCEEDED or _worker_command_configured():
+                _WORKER_AUTO_SETUP_SUCCEEDED = True
+                return True
+            if _WORKER_AUTO_SETUP_ATTEMPTED:
+                return False
+            _WORKER_AUTO_SETUP_ATTEMPTED = True
 
-        try:
-            proc = subprocess.run(
-                cmd,
-                cwd=str(repo_root),
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=setup_timeout_sec,
+            setup_timeout_sec = _get_env_int("MATCHA_CONFORMER_WORKER_SETUP_TIMEOUT_SEC", 3600)
+            cmd = ["uv", "run", "python", str(setup_script), "--skip-smoke"]
+            logger.info(
+                "Conformer worker is not installed; running automatic setup "
+                "(set MATCHA_CONFORMER_AUTO_SETUP_WORKER=0 to disable)"
             )
-        except subprocess.TimeoutExpired:
-            logger.warning(
-                f"Automatic conformer worker setup timed out after {setup_timeout_sec}s; "
-                "falling back to RDKit"
-            )
-            return False
 
-        if proc.returncode != 0:
-            stderr_tail = "\n".join(proc.stderr.strip().splitlines()[-20:])
-            stdout_tail = "\n".join(proc.stdout.strip().splitlines()[-20:])
-            details = stderr_tail or stdout_tail or "setup exited with non-zero status"
-            logger.warning(
-                f"Automatic conformer worker setup failed (code={proc.returncode}); "
-                f"falling back to RDKit.\n{details}"
-            )
-            return False
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    cwd=str(repo_root),
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=setup_timeout_sec,
+                )
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    f"Automatic conformer worker setup timed out after {setup_timeout_sec}s; "
+                    "falling back to RDKit"
+                )
+                return False
 
-        if not _worker_command_configured():
-            logger.warning(
-                "Automatic conformer worker setup finished but worker command was not found; "
-                "falling back to RDKit"
-            )
-            return False
+            if proc.returncode != 0:
+                stderr_tail = "\n".join(proc.stderr.strip().splitlines()[-20:])
+                stdout_tail = "\n".join(proc.stdout.strip().splitlines()[-20:])
+                details = stderr_tail or stdout_tail or "setup exited with non-zero status"
+                logger.warning(
+                    f"Automatic conformer worker setup failed (code={proc.returncode}); "
+                    f"falling back to RDKit.\n{details}"
+                )
+                return False
 
-        _WORKER_AUTO_SETUP_SUCCEEDED = True
-        logger.info("Automatic conformer worker setup completed successfully")
-        return True
+            if not _worker_command_configured():
+                logger.warning(
+                    "Automatic conformer worker setup finished but worker command was not found; "
+                    "falling back to RDKit"
+                )
+                return False
+
+            _WORKER_AUTO_SETUP_SUCCEEDED = True
+            logger.info("Automatic conformer worker setup completed successfully")
+            return True
 
 
 def _split_single_conformer_mols(mol, num_conformers: int):

--- a/matcha/utils/preprocessing.py
+++ b/matcha/utils/preprocessing.py
@@ -383,11 +383,10 @@ def generate_multiple_conformers(orig_mol, num_conformers):
     mol = copy.deepcopy(orig_mol)
     ps = AllChem.ETKDGv3()
     failures, ids = 0, []
-    max_failures = 3
-    max_iterations = max_failures  # Prevent infinite loops
+    max_attempts = 3
 
     iteration = 0
-    while mol.GetNumConformers() < num_conformers and iteration < max_iterations:
+    while mol.GetNumConformers() < num_conformers and iteration < max_attempts:
         current_count = mol.GetNumConformers()
         needed = num_conformers - current_count
 
@@ -405,20 +404,18 @@ def generate_multiple_conformers(orig_mol, num_conformers):
 
         ids = [id for id in ids if id != -1]
 
-        # Manually add each new conformer to the main molecule
         added_count = 0
         for conf_id in ids:
-                conf = temp_mol.GetConformer(conf_id)
-                mol.AddConformer(conf, assignId=True)
-                added_count += 1
-        
+            conf = temp_mol.GetConformer(conf_id)
+            mol.AddConformer(conf, assignId=True)
+            added_count += 1
+
         new_count = mol.GetNumConformers()
 
         if added_count == 0:
-            # No new conformers were added
-            logger.debug(f"No new conformers added. Retrying {iteration + 1}/{max_iterations}")
+            logger.debug(f"No new conformers added. Retrying {iteration + 1}/{max_attempts}")
             failures += 1
-            if failures >= max_failures:
+            if failures >= max_attempts:
                 break
         else:
             # Successfully added some conformers, reset failure counter
@@ -452,9 +449,9 @@ def generate_multiple_conformers(orig_mol, num_conformers):
     if mol.GetNumConformers() == 0:
         logger.warning("No conformers generated, using original molecule")
         return orig_mol
-    else:
-        logger.debug(f"Generated {mol.GetNumConformers()} conformers")
-        return mol
+
+    logger.debug(f"Generated {mol.GetNumConformers()} conformers")
+    return mol
 
 
 def generate_conformer_mols(orig_mol, num_conformers, backend: str | None = None):
@@ -501,7 +498,6 @@ def generate_conformer_mols_batch(
 
     results = [None] * len(mols)
 
-    # Prepare molecules: keep originals intact for safety.
     prepared = []
     for mol in mols:
         init = copy.deepcopy(mol)
@@ -519,6 +515,17 @@ def generate_conformer_mols_batch(
 
     use_worker = backend == "worker" or (backend == "auto" and worker_cmd_configured)
     worker_disabled = False
+
+    def _rdkit_generate_chunk(chunk_mols):
+        result = []
+        for m in chunk_mols:
+            m_with_confs = generate_multiple_conformers(m, int(confs_per_mol))
+            m_with_confs = _remove_hs_safe(m_with_confs)
+            result.append(_split_single_conformer_mols(m_with_confs, int(confs_per_mol)))
+        if "rdkit" not in _CONFORMER_BACKEND_LOGGED:
+            logger.info("Conformer backend: RDKit")
+            _CONFORMER_BACKEND_LOGGED.add("rdkit")
+        return result
 
     for start in range(0, len(prepared), chunk_size):
         end = min(len(prepared), start + chunk_size)
@@ -538,29 +545,13 @@ def generate_conformer_mols_batch(
                     logger.info("Conformer backend: worker")
                     _CONFORMER_BACKEND_LOGGED.add("worker")
             else:
-                chunk_results = []
-                for mol in chunk:
-                    mol_with_confs = generate_multiple_conformers(mol, int(confs_per_mol))
-                    mol_with_confs = _remove_hs_safe(mol_with_confs)
-                    chunk_results.append(
-                        _split_single_conformer_mols(mol_with_confs, int(confs_per_mol))
-                    )
-                if "rdkit" not in _CONFORMER_BACKEND_LOGGED:
-                    logger.info("Conformer backend: RDKit")
-                    _CONFORMER_BACKEND_LOGGED.add("rdkit")
+                chunk_results = _rdkit_generate_chunk(chunk)
         except Exception as exc:
             if backend == "worker":
                 raise RuntimeError(f"Worker conformer generation failed: {exc}") from exc
             worker_disabled = True
             logger.warning(f"Worker conformer backend failed, falling back to RDKit: {exc}")
-            chunk_results = []
-            for mol in chunk:
-                mol_with_confs = generate_multiple_conformers(mol, int(confs_per_mol))
-                mol_with_confs = _remove_hs_safe(mol_with_confs)
-                chunk_results.append(_split_single_conformer_mols(mol_with_confs, int(confs_per_mol)))
-            if "rdkit" not in _CONFORMER_BACKEND_LOGGED:
-                logger.info("Conformer backend: RDKit")
-                _CONFORMER_BACKEND_LOGGED.add("rdkit")
+            chunk_results = _rdkit_generate_chunk(chunk)
 
         for local_idx, conformer_mols in enumerate(chunk_results):
             processed = []
@@ -582,7 +573,6 @@ def generate_conformer_mols_batch(
                 processed = _split_single_conformer_mols(fallback, 1)
             results[start + local_idx] = processed
 
-    # Satisfy type checker: results is fully populated.
     return [r if r is not None else [copy.deepcopy(mols[i])] for i, r in enumerate(results)]
 
 
@@ -615,8 +605,7 @@ def safe_index(items, element):
 
 
 def parse_receptor(pdbid, pdbbind_dir, dataset_type):
-    rec = parsePDB(pdbid, pdbbind_dir, dataset_type)
-    return rec
+    return parsePDB(pdbid, pdbbind_dir, dataset_type)
 
 
 def parsePDB(pdbid, pdbbind_dir, dataset_type):

--- a/matcha/utils/preprocessing.py
+++ b/matcha/utils/preprocessing.py
@@ -2,6 +2,7 @@ import copy
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import tempfile
 import threading
@@ -28,6 +29,9 @@ _CONFORMER_BACKEND_LOGGED: set[str] = set()
 
 _PDB_PARSE_CACHE_LOCK = threading.Lock()
 _PDB_PARSE_CACHE: dict[tuple, object] = {}
+_WORKER_AUTO_SETUP_LOCK = threading.Lock()
+_WORKER_AUTO_SETUP_ATTEMPTED = False
+_WORKER_AUTO_SETUP_SUCCEEDED = False
 
 
 biopython_parser = PDBParser()
@@ -251,6 +255,101 @@ def _resolve_worker_command() -> list[str]:
         "MATCHA_CONFORMER_WORKER_CMD is not set and no local worker command was found at "
         f"{worker_entry}. Run: uv run python scripts/setup_nvmolkit_worker.py"
     )
+
+
+def _worker_command_configured() -> bool:
+    if os.environ.get("MATCHA_CONFORMER_WORKER_CMD", "").strip():
+        return True
+
+    repo_root = Path(__file__).resolve().parents[2]
+    worker_entry = repo_root / ".venv-nvmolkit-worker" / "bin" / "matcha-nvmolkit-worker"
+    worker_script = repo_root / "scripts" / "nvmolkit_worker.py"
+    venv_python = repo_root / ".venv-nvmolkit-worker" / "bin" / "python"
+    return worker_entry.exists() or (worker_script.exists() and venv_python.exists())
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    if normalized == "":
+        return default
+    logger.warning(f"Invalid boolean for {name}: {value}, using default {default}")
+    return default
+
+
+def _auto_setup_worker_once() -> bool:
+    global _WORKER_AUTO_SETUP_ATTEMPTED, _WORKER_AUTO_SETUP_SUCCEEDED
+
+    with _WORKER_AUTO_SETUP_LOCK:
+        if _WORKER_AUTO_SETUP_SUCCEEDED:
+            return True
+        if _WORKER_AUTO_SETUP_ATTEMPTED:
+            return False
+        _WORKER_AUTO_SETUP_ATTEMPTED = True
+
+        if not _env_flag("MATCHA_CONFORMER_AUTO_SETUP_WORKER", True):
+            logger.info("Conformer worker auto-setup is disabled by MATCHA_CONFORMER_AUTO_SETUP_WORKER")
+            return False
+
+        repo_root = Path(__file__).resolve().parents[2]
+        setup_script = repo_root / "scripts" / "setup_nvmolkit_worker.py"
+        if not setup_script.exists():
+            logger.warning(f"Worker setup script not found: {setup_script}")
+            return False
+
+        if shutil.which("uv") is None:
+            logger.warning("Cannot auto-setup conformer worker because `uv` is not in PATH")
+            return False
+
+        setup_timeout_sec = _get_env_int("MATCHA_CONFORMER_WORKER_SETUP_TIMEOUT_SEC", 3600)
+        cmd = ["uv", "run", "python", str(setup_script), "--skip-smoke"]
+        logger.info(
+            "Conformer worker is not installed; running automatic setup "
+            "(set MATCHA_CONFORMER_AUTO_SETUP_WORKER=0 to disable)"
+        )
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(repo_root),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=setup_timeout_sec,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                f"Automatic conformer worker setup timed out after {setup_timeout_sec}s; "
+                "falling back to RDKit"
+            )
+            return False
+
+        if proc.returncode != 0:
+            stderr_tail = "\n".join(proc.stderr.strip().splitlines()[-20:])
+            stdout_tail = "\n".join(proc.stdout.strip().splitlines()[-20:])
+            details = stderr_tail or stdout_tail or "setup exited with non-zero status"
+            logger.warning(
+                f"Automatic conformer worker setup failed (code={proc.returncode}); "
+                f"falling back to RDKit.\n{details}"
+            )
+            return False
+
+        if not _worker_command_configured():
+            logger.warning(
+                "Automatic conformer worker setup finished but worker command was not found; "
+                "falling back to RDKit"
+            )
+            return False
+
+        _WORKER_AUTO_SETUP_SUCCEEDED = True
+        logger.info("Automatic conformer worker setup completed successfully")
+        return True
 
 
 def _split_single_conformer_mols(mol, num_conformers: int):
@@ -505,15 +604,17 @@ def generate_conformer_mols_batch(
         init = Chem.AddHs(init)
         prepared.append(init)
 
-    worker_cmd_configured = bool(os.environ.get("MATCHA_CONFORMER_WORKER_CMD", "").strip())
-    if not worker_cmd_configured:
-        repo_root = Path(__file__).resolve().parents[2]
-        worker_entry = repo_root / ".venv-nvmolkit-worker" / "bin" / "matcha-nvmolkit-worker"
-        worker_script = repo_root / "scripts" / "nvmolkit_worker.py"
-        venv_python = repo_root / ".venv-nvmolkit-worker" / "bin" / "python"
-        worker_cmd_configured = worker_entry.exists() or (worker_script.exists() and venv_python.exists())
+    worker_cmd_configured = _worker_command_configured()
+    if backend in {"auto", "worker"} and not worker_cmd_configured:
+        if _auto_setup_worker_once():
+            worker_cmd_configured = _worker_command_configured()
 
     use_worker = backend == "worker" or (backend == "auto" and worker_cmd_configured)
+    if backend == "worker" and not worker_cmd_configured:
+        raise RuntimeError(
+            "Worker conformer backend was requested but worker command is unavailable. "
+            "Run: uv run python scripts/setup_nvmolkit_worker.py"
+        )
     worker_disabled = False
 
     def _rdkit_generate_chunk(chunk_mols):

--- a/matcha/utils/preprocessing.py
+++ b/matcha/utils/preprocessing.py
@@ -1,24 +1,33 @@
-import os
 import copy
+import json
+import os
+import shlex
+import subprocess
+import tempfile
 import threading
+import time
 from queue import Queue
+from pathlib import Path
 
 import numpy as np
-import struct
-import torch
-from Bio.PDB import PDBParser
 from rdkit.Chem.rdchem import BondType as BT
 from rdkit import Chem
 from rdkit.Chem import AllChem, GetPeriodicTable
-from rdkit.Geometry import Point3D
-from Bio.PDB import PDBParser, MMCIFParser, PDBIO, Select
+from Bio.PDB import PDBParser
+from scipy.spatial import cKDTree
 
 import prody
 from prody import confProDy
-confProDy(verbosity='none')
-
 from matcha.utils.log import get_logger
+
+confProDy(verbosity='none')
 logger = get_logger(__name__)
+
+_CONFORMER_BACKEND_LOGGED: set[str] = set()
+
+
+_PDB_PARSE_CACHE_LOCK = threading.Lock()
+_PDB_PARSE_CACHE: dict[tuple, object] = {}
 
 
 biopython_parser = PDBParser()
@@ -204,6 +213,172 @@ def _optimize_confs_with_timeout(mol, start_idx, end_idx, timeout_seconds):
     return False  # Success
 
 
+def _get_env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        logger.warning(f"Invalid integer for {name}: {value}, using default {default}")
+        return default
+    if parsed <= 0:
+        logger.warning(f"Expected positive integer for {name}: {value}, using default {default}")
+        return default
+    return parsed
+
+
+def _resolve_worker_command() -> list[str]:
+    raw_cmd = os.environ.get("MATCHA_CONFORMER_WORKER_CMD", "").strip()
+    if raw_cmd:
+        cmd_parts = shlex.split(raw_cmd)
+        if not cmd_parts:
+            raise ValueError("MATCHA_CONFORMER_WORKER_CMD has no executable")
+        return cmd_parts
+
+    # Auto-discover a local worker venv created via scripts/setup_nvmolkit_worker.py.
+    repo_root = Path(__file__).resolve().parents[2]
+    worker_entry = repo_root / ".venv-nvmolkit-worker" / "bin" / "matcha-nvmolkit-worker"
+    if worker_entry.exists():
+        return [str(worker_entry)]
+
+    worker_script = repo_root / "scripts" / "nvmolkit_worker.py"
+    venv_python = repo_root / ".venv-nvmolkit-worker" / "bin" / "python"
+    if worker_script.exists() and venv_python.exists():
+        return [str(venv_python), str(worker_script)]
+
+    raise ValueError(
+        "MATCHA_CONFORMER_WORKER_CMD is not set and no local worker command was found at "
+        f"{worker_entry}. Run: uv run python scripts/setup_nvmolkit_worker.py"
+    )
+
+
+def _split_single_conformer_mols(mol, num_conformers: int):
+    if mol.GetNumConformers() == 0:
+        return [copy.deepcopy(mol)]
+
+    conformer_mols = []
+    for cid in range(mol.GetNumConformers()):
+        m = Chem.Mol(mol)
+        conf = mol.GetConformer(cid)
+        m.RemoveAllConformers()
+        m.AddConformer(conf, assignId=True)
+        m.SetProp("ID", f"conformer_{cid}")
+        conformer_mols.append(m)
+        if len(conformer_mols) >= num_conformers:
+            break
+    return conformer_mols
+
+
+def _remove_hs_safe(mol):
+    try:
+        return Chem.RemoveAllHs(mol)
+    except Exception:
+        return Chem.RemoveAllHs(mol, sanitize=False)
+
+
+def _conformer_has_finite_coords(mol) -> bool:
+    if mol is None or mol.GetNumConformers() == 0:
+        return False
+    try:
+        pos = np.asarray(mol.GetConformer(0).GetPositions(), dtype=np.float64)
+    except Exception:
+        return False
+    return pos.ndim == 2 and pos.shape[1] == 3 and np.isfinite(pos).all()
+
+
+def _generate_worker_batch(
+    molecules,
+    confs_per_mol: int,
+    seed: int | None,
+    optimize: bool,
+    chunk_size: int,
+):
+    worker_timeout_sec = _get_env_int("MATCHA_CONFORMER_WORKER_TIMEOUT_SEC", 300)
+    worker_cmd = _resolve_worker_command()
+
+    with tempfile.TemporaryDirectory(prefix="matcha_conformer_worker_") as tmp_dir:
+        work_dir = os.path.abspath(tmp_dir)
+        input_sdf = os.path.join(work_dir, "input.sdf")
+        params_json = os.path.join(work_dir, "params.json")
+        output_sdf = os.path.join(work_dir, "output.sdf")
+        meta_json = os.path.join(work_dir, "meta.json")
+
+        writer = Chem.SDWriter(input_sdf)
+        writer.SetKekulize(False)
+        uids = []
+        for idx, mol in enumerate(molecules):
+            uid = f"mol_{idx}"
+            current = Chem.Mol(mol)
+            current.SetProp("_Name", uid)
+            writer.write(current)
+            uids.append(uid)
+        writer.close()
+
+        params = {
+            "confs_per_mol": int(confs_per_mol),
+            "seed": int(seed) if seed is not None else None,
+            "optimize": bool(optimize),
+            "chunk_size": int(chunk_size),
+        }
+        with open(params_json, "w", encoding="utf-8") as f:
+            json.dump(params, f)
+
+        cmd = [
+            *worker_cmd,
+            "--input-sdf",
+            input_sdf,
+            "--params-json",
+            params_json,
+            "--output-sdf",
+            output_sdf,
+            "--meta-json",
+            meta_json,
+        ]
+
+        started_at = time.time()
+        try:
+            proc = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=worker_timeout_sec,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Worker timeout after {worker_timeout_sec}s for command: {' '.join(cmd)}"
+            ) from exc
+        elapsed = time.time() - started_at
+
+        if proc.returncode != 0:
+            stderr = proc.stderr.strip()
+            stdout = proc.stdout.strip()
+            worker_message = stderr or stdout or "worker exited with non-zero status"
+            raise RuntimeError(
+                f"Worker process failed (code={proc.returncode}, elapsed={elapsed:.2f}s): "
+                f"{worker_message}"
+            )
+
+        if not os.path.exists(output_sdf):
+            raise RuntimeError("Worker finished without output.sdf")
+
+        grouped = {uid: [] for uid in uids}
+        supplier = Chem.SDMolSupplier(output_sdf, sanitize=False, removeHs=False)
+        for mol in supplier:
+            if mol is None:
+                continue
+            uid = mol.GetProp("_Name") if mol.HasProp("_Name") else ""
+            if uid in grouped:
+                grouped[uid].append(mol)
+
+        missing = [uid for uid, confs in grouped.items() if not confs]
+        if missing:
+            raise RuntimeError(f"Worker did not return conformers for {len(missing)} molecules")
+
+        return [grouped[uid][: int(confs_per_mol)] for uid in uids]
+
+
 def generate_multiple_conformers(orig_mol, num_conformers):
     mol = copy.deepcopy(orig_mol)
     ps = AllChem.ETKDGv3()
@@ -220,18 +395,19 @@ def generate_multiple_conformers(orig_mol, num_conformers):
         temp_mol = copy.deepcopy(orig_mol)
         temp_mol.RemoveAllConformers()
         try:
-            ids = AllChem.EmbedMultipleConfs(temp_mol, needed, ps)
-        except Exception as e:
+            ids, timed_out = _embed_confs_with_timeout(temp_mol, needed, ps, 60)
+            if timed_out or ids is None:
+                logger.warning("Conformer embedding timed out, using initial molecule")
+                return orig_mol
+        except Exception:
             logger.warning("Unable to generate conformers, using initial molecule")
             return orig_mol
 
-        ids = [id for id in ids]
         ids = [id for id in ids if id != -1]
-        
+
         # Manually add each new conformer to the main molecule
         added_count = 0
         for conf_id in ids:
-            if conf_id != -1:
                 conf = temp_mol.GetConformer(conf_id)
                 mol.AddConformer(conf, assignId=True)
                 added_count += 1
@@ -254,58 +430,35 @@ def generate_multiple_conformers(orig_mol, num_conformers):
     if mol.GetNumConformers() == 0:
         logger.debug("RDKit coords generation failed without random coords, using random coords")
         ps.useRandomCoords = True
-        ids, timed_out = _embed_confs_with_timeout(mol, min(num_conformers, 10), ps, 600)
-            
+        ids, timed_out = _embed_confs_with_timeout(mol, min(num_conformers, 10), ps, 60)
+
         if not timed_out and ids is not None:
             ids = [id for id in ids if id != -1]
             for conf_id in ids:
-                conf = mol.GetConformer(conf_id)
-                # Optimize with timeout
                 timed_out = _optimize_confs_with_timeout(mol, conf_id, conf_id + 1, 60)
                 if timed_out:
                     logger.warning(f"Optimization timed out for conformer {conf_id}")
         else:
             logger.debug("using random coords now with 1 conformer")
-            ids, timed_out = _embed_confs_with_timeout(mol, 1, ps, 600)
-                
+            ids, timed_out = _embed_confs_with_timeout(mol, 1, ps, 60)
+
             if not timed_out and ids is not None:
                 ids = [id for id in ids if id != -1]
                 for conf_id in ids:
-                    conf = mol.GetConformer(conf_id)
-                    # Optimize with timeout
                     timed_out = _optimize_confs_with_timeout(mol, conf_id, conf_id + 1, 60)
                     if timed_out:
                         logger.error(f'Optimization timed out for conformer {conf_id}')
     
     if mol.GetNumConformers() == 0:
-        logger.warning(f"No conformers generated, using original molecule")
+        logger.warning("No conformers generated, using original molecule")
         return orig_mol
     else:
         logger.debug(f"Generated {mol.GetNumConformers()} conformers")
         return mol
 
 
-def _split_single_conformer_mols(mol, max_confs):
-    """Split a multi-conformer mol into a list of single-conformer mols."""
-    res = []
-    if mol is None or mol.GetNumConformers() == 0:
-        return res
-    for conf_id in range(min(int(max_confs), mol.GetNumConformers())):
-        conf_mol = copy.deepcopy(mol)
-        conf = mol.GetConformer(conf_id)
-        conf_mol.RemoveAllConformers()
-        conf_mol.AddConformer(conf, assignId=True)
-        if not conf_mol.HasProp("ID"):
-            conf_mol.SetProp("ID", f"conformer_{conf_id}")
-        res.append(conf_mol)
-    return res
-
-
-def generate_conformer_mols(orig_mol, num_conformers, backend=None):
-    """Generate a list of single-conformer RDKit molecules.
-
-    `backend` is accepted for forward compatibility with worker-based backends.
-    """
+def generate_conformer_mols(orig_mol, num_conformers, backend: str | None = None):
+    """Generate a list of single-conformer RDKit molecules."""
     return generate_conformer_mols_batch(
         [orig_mol],
         confs_per_mol=int(num_conformers),
@@ -315,35 +468,122 @@ def generate_conformer_mols(orig_mol, num_conformers, backend=None):
 
 def generate_conformer_mols_batch(
     mols,
-    confs_per_mol,
-    backend=None,
-    seed=None,
-    optimize=True,
-    chunk_size=128,
+    confs_per_mol: int,
+    backend: str | None = None,
+    seed: int | None = None,
+    optimize: bool = True,
+    chunk_size: int = 128,
 ):
-    """RDKit batch conformer generation fallback.
+    """Generate conformers for a batch of molecules.
 
-    Current implementation intentionally uses RDKit only. Additional arguments
-    are accepted for API compatibility with optional worker-based generators.
+    Returns:
+        A list of lists, aligned with the input `mols`. Each inner list contains
+        single-conformer RDKit molecules.
     """
+    backend = (backend or os.environ.get("MATCHA_CONFORMER_BACKEND", "auto")).lower()
+    if backend not in {"auto", "rdkit", "worker"}:
+        raise ValueError(f"Unknown conformer backend: {backend}")
+
+    if seed is None:
+        seed_env = os.environ.get("MATCHA_CONFORMER_SEED")
+        if seed_env is not None and seed_env.strip():
+            try:
+                seed = int(seed_env)
+            except ValueError:
+                seed = None
+
     if confs_per_mol <= 0:
         return [[copy.deepcopy(m)] for m in mols]
 
-    results = []
+    if chunk_size < 1:
+        chunk_size = len(mols) or 1
+    worker_chunk_size = _get_env_int("MATCHA_CONFORMER_WORKER_CHUNK_SIZE", int(chunk_size))
+
+    results = [None] * len(mols)
+
+    # Prepare molecules: keep originals intact for safety.
+    prepared = []
     for mol in mols:
         init = copy.deepcopy(mol)
         init.RemoveAllConformers()
         init = Chem.AddHs(init)
-        conf_mol = generate_multiple_conformers(init, int(confs_per_mol))
-        conf_mol = Chem.RemoveAllHs(conf_mol)
-        confs = _split_single_conformer_mols(conf_mol, int(confs_per_mol))
-        if len(confs) == 0:
-            fallback = copy.deepcopy(mol)
-            confs = _split_single_conformer_mols(fallback, 1)
-            if len(confs) == 0:
-                confs = [fallback]
-        results.append(confs)
-    return results
+        prepared.append(init)
+
+    worker_cmd_configured = bool(os.environ.get("MATCHA_CONFORMER_WORKER_CMD", "").strip())
+    if not worker_cmd_configured:
+        repo_root = Path(__file__).resolve().parents[2]
+        worker_entry = repo_root / ".venv-nvmolkit-worker" / "bin" / "matcha-nvmolkit-worker"
+        worker_script = repo_root / "scripts" / "nvmolkit_worker.py"
+        venv_python = repo_root / ".venv-nvmolkit-worker" / "bin" / "python"
+        worker_cmd_configured = worker_entry.exists() or (worker_script.exists() and venv_python.exists())
+
+    use_worker = backend == "worker" or (backend == "auto" and worker_cmd_configured)
+    worker_disabled = False
+
+    for start in range(0, len(prepared), chunk_size):
+        end = min(len(prepared), start + chunk_size)
+        chunk = prepared[start:end]
+        chunk_results = None
+
+        try:
+            if use_worker and not worker_disabled:
+                chunk_results = _generate_worker_batch(
+                    chunk,
+                    confs_per_mol=int(confs_per_mol),
+                    seed=seed,
+                    optimize=optimize,
+                    chunk_size=worker_chunk_size,
+                )
+                if "worker" not in _CONFORMER_BACKEND_LOGGED:
+                    logger.info("Conformer backend: worker")
+                    _CONFORMER_BACKEND_LOGGED.add("worker")
+            else:
+                chunk_results = []
+                for mol in chunk:
+                    mol_with_confs = generate_multiple_conformers(mol, int(confs_per_mol))
+                    mol_with_confs = _remove_hs_safe(mol_with_confs)
+                    chunk_results.append(
+                        _split_single_conformer_mols(mol_with_confs, int(confs_per_mol))
+                    )
+                if "rdkit" not in _CONFORMER_BACKEND_LOGGED:
+                    logger.info("Conformer backend: RDKit")
+                    _CONFORMER_BACKEND_LOGGED.add("rdkit")
+        except Exception as exc:
+            if backend == "worker":
+                raise RuntimeError(f"Worker conformer generation failed: {exc}") from exc
+            worker_disabled = True
+            logger.warning(f"Worker conformer backend failed, falling back to RDKit: {exc}")
+            chunk_results = []
+            for mol in chunk:
+                mol_with_confs = generate_multiple_conformers(mol, int(confs_per_mol))
+                mol_with_confs = _remove_hs_safe(mol_with_confs)
+                chunk_results.append(_split_single_conformer_mols(mol_with_confs, int(confs_per_mol)))
+            if "rdkit" not in _CONFORMER_BACKEND_LOGGED:
+                logger.info("Conformer backend: RDKit")
+                _CONFORMER_BACKEND_LOGGED.add("rdkit")
+
+        for local_idx, conformer_mols in enumerate(chunk_results):
+            processed = []
+            for conf_idx, conf_mol in enumerate(conformer_mols):
+                conf_mol = _remove_hs_safe(conf_mol)
+                if conf_mol.GetNumConformers() == 0:
+                    continue
+                if not _conformer_has_finite_coords(conf_mol):
+                    continue
+                if not conf_mol.HasProp("ID"):
+                    conf_mol.SetProp("ID", f"conformer_{conf_idx}")
+                processed.append(conf_mol)
+                if len(processed) >= int(confs_per_mol):
+                    break
+            if not processed:
+                fallback = copy.deepcopy(mols[start + local_idx])
+                if fallback.GetNumConformers() > 0 and not _conformer_has_finite_coords(fallback):
+                    fallback.RemoveAllConformers()
+                processed = _split_single_conformer_mols(fallback, 1)
+            results[start + local_idx] = processed
+
+    # Satisfy type checker: results is fully populated.
+    return [r if r is not None else [copy.deepcopy(mols[i])] for i, r in enumerate(results)]
 
 
 def save_multiple_confs(mol, output_conf_path, num_conformers):
@@ -358,6 +598,7 @@ def save_multiple_confs(mol, output_conf_path, num_conformers):
         mol = Chem.RemoveAllHs(init_mol)
 
     writer = Chem.SDWriter(output_conf_path)
+    writer.SetKekulize(False)
     for cid in range(mol.GetNumConformers()):
         mol.SetProp('ID', f'conformer_{cid}')
         writer.write(mol, confId=cid)
@@ -365,12 +606,12 @@ def save_multiple_confs(mol, output_conf_path, num_conformers):
     return mol
 
 
-def safe_index(l, e):
-    """ Return index of element e in list l. If e is not present, return the last index """
+def safe_index(items, element):
+    """Return index of element in items or the last index if absent."""
     try:
-        return l.index(e)
-    except:
-        return len(l) - 1
+        return items.index(element)
+    except ValueError:
+        return len(items) - 1
 
 
 def parse_receptor(pdbid, pdbbind_dir, dataset_type):
@@ -379,12 +620,10 @@ def parse_receptor(pdbid, pdbbind_dir, dataset_type):
 
 
 def parsePDB(pdbid, pdbbind_dir, dataset_type):
-    if dataset_type == 'pdbbind' or dataset_type == 'pdbbind_conf' or \
-            dataset_type == 'dockgen' or dataset_type == 'dockgen_full' or dataset_type == 'dockgen_full_conf':
+    if dataset_type in {'pdbbind', 'pdbbind_conf', 'dockgen', 'dockgen_full', 'dockgen_full_conf'}:
         rec_path = os.path.join(
             pdbbind_dir, pdbid, f'{pdbid}_protein_processed.pdb')
-    elif dataset_type.startswith('posebusters') or dataset_type.startswith('astex') \
-            or dataset_type.startswith('any'):
+    elif dataset_type.startswith(('posebusters', 'astex', 'any')):
         rec_path = os.path.join(pdbbind_dir, pdbid, f'{pdbid}_protein.pdb')
     else:
         raise ValueError(f'Unknown dataset type: {dataset_type}')
@@ -393,7 +632,33 @@ def parsePDB(pdbid, pdbbind_dir, dataset_type):
 
 
 def parse_pdb_from_path(path):
-    pdb = prody.parsePDB(path)
+    """Parse a PDB file via ProDy with a small in-process cache.
+
+    Batch docking often repeats the same receptor for hundreds of ligands. In CLI
+    batch mode we symlink each per-ligand receptor path to a single underlying
+    file, so caching by realpath + stat dramatically reduces repeated parsing.
+    """
+    real_path = os.path.realpath(path)
+    st = os.stat(real_path)
+    key = (
+        real_path,
+        getattr(st, "st_dev", None),
+        getattr(st, "st_ino", None),
+        st.st_size,
+        getattr(st, "st_mtime_ns", int(st.st_mtime * 1e9)),
+    )
+
+    with _PDB_PARSE_CACHE_LOCK:
+        cached = _PDB_PARSE_CACHE.get(key)
+    if cached is not None:
+        try:
+            return cached.copy()
+        except Exception:
+            return cached
+
+    pdb = prody.parsePDB(real_path)
+    with _PDB_PARSE_CACHE_LOCK:
+        _PDB_PARSE_CACHE[key] = pdb
     return pdb
 
 
@@ -484,7 +749,7 @@ def read_molecule(molecule_file, sanitize=False, remove_hs=False, strict=False):
         if sanitize:
             try:
                 Chem.SanitizeMol(mol)
-            except Exception as e:
+            except Exception:
                 logger.warning("RDKit was unable to sanitize the molecule")
                 if strict:
                     return None
@@ -492,7 +757,7 @@ def read_molecule(molecule_file, sanitize=False, remove_hs=False, strict=False):
         if remove_hs:
             try:
                 mol = Chem.RemoveAllHs(mol, sanitize=sanitize)
-            except Exception as e:
+            except Exception:
                 logger.warning("RDKit was unable to remove hydrogen atoms from the molecule")
                 if strict:
                     return None
@@ -590,10 +855,16 @@ def extract_receptor_structure_prody(rec, lig, sequences_to_embeddings):
 
         min_dist_to_lig = 0
         if lig is not None:
-            distances = np.linalg.norm(
-                lig_coords[None] - nonempty_coords[:, None], axis=-1)
-            min_dist_arr = distances.min(axis=0)
-            min_dist_to_lig = distances.min()
+            # Fast nearest-neighbour distances: for each ligand atom, compute distance to
+            # the closest protein atom in this chain (equivalent to min over rows).
+            tree = cKDTree(nonempty_coords)
+            try:
+                min_dist_arr, _ = tree.query(lig_coords, k=1, workers=-1)
+            except TypeError:
+                # Older SciPy without `workers` argument.
+                min_dist_arr, _ = tree.query(lig_coords, k=1)
+            min_dist_arr = np.asarray(min_dist_arr)
+            min_dist_to_lig = float(min_dist_arr.min())
             chain_distances[chain_id] = min_dist_to_lig
 
         if min_dist_to_lig < 4.5:
@@ -614,7 +885,7 @@ def extract_receptor_structure_prody(rec, lig, sequences_to_embeddings):
 
     if len(c_alpha_coords) == 0:
         logger.error(f"NO VALID CHAIN found, chain_distances: {chain_distances}")
-        return None, None, None, None, None, None
+        return None, None, None, None, None, None, None
 
     chain_lengths = [(len(seq), dist) for seq, dist in zip(sequences, chain_distances_list)]
     c_alpha_coords = np.concatenate(c_alpha_coords, axis=0)  # [n_residues, 3]
@@ -629,13 +900,13 @@ def extract_receptor_structure_prody(rec, lig, sequences_to_embeddings):
         min_distances_to_lig = min_distances_to_lig.min(axis=0)
 
         distance_cutoff = 5.
-        is_buried_threshold = 0.3  # -100
+        is_buried_threshold = 0.3
         buried_atoms_mask = min_distances_to_lig <= distance_cutoff
         fraction_buried = buried_atoms_mask.mean()
 
         if fraction_buried < is_buried_threshold:
             logger.warning(
                 f"Ligand is not buried (fraction_buried = {fraction_buried})")
-            return None, None, None, None, None, None
+            return None, None, None, None, None, None, None
 
     return c_alpha_coords, lm_embeddings, sequences, chain_lengths, full_coords, full_atom_names, full_atom_residue_ids

--- a/packages/matcha_nvmolkit_worker/README.md
+++ b/packages/matcha_nvmolkit_worker/README.md
@@ -1,0 +1,3 @@
+# matcha-nvmolkit-worker
+
+Isolated nvMolKit worker package for Matcha conformer generation.

--- a/packages/matcha_nvmolkit_worker/pyproject.toml
+++ b/packages/matcha_nvmolkit_worker/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "matcha-nvmolkit-worker"
+version = "0.1.0"
+description = "Isolated nvMolKit worker process for Matcha conformer generation"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "rdkit>=2025.9.1",
+]
+
+[project.scripts]
+matcha-nvmolkit-worker = "matcha_nvmolkit_worker.cli:main"
+
+[build-system]
+requires = ["uv_build>=0.9.18,<0.10.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-root = "src"

--- a/packages/matcha_nvmolkit_worker/src/matcha_nvmolkit_worker/__init__.py
+++ b/packages/matcha_nvmolkit_worker/src/matcha_nvmolkit_worker/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["main"]
+
+from .cli import main

--- a/packages/matcha_nvmolkit_worker/src/matcha_nvmolkit_worker/cli.py
+++ b/packages/matcha_nvmolkit_worker/src/matcha_nvmolkit_worker/cli.py
@@ -1,0 +1,307 @@
+import argparse
+import ctypes
+import importlib
+import json
+import math
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+from rdkit import Chem
+from rdkit.Chem.rdDistGeom import ETKDGv3
+from rdkit.Geometry import Point3D
+
+
+def _prepend_ld_library_path(path: Path):
+    current = os.environ.get("LD_LIBRARY_PATH", "")
+    parts = [p for p in current.split(":") if p]
+    path_str = str(path)
+    if path_str not in parts:
+        os.environ["LD_LIBRARY_PATH"] = ":".join([path_str, *parts]) if parts else path_str
+
+
+def _prepare_runtime():
+    nvidia_modules = [
+        "nvidia.cuda_runtime",
+        "nvidia.cublas",
+        "nvidia.cudnn",
+        "nvidia.cufft",
+        "nvidia.curand",
+        "nvidia.cusolver",
+        "nvidia.cusparse",
+        "nvidia.nvjitlink",
+        "nvidia.nvtx",
+    ]
+    discovered_lib_dirs = []
+    for module_name in nvidia_modules:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception:
+            continue
+        module_file = getattr(module, "__file__", None)
+        if module_file is None:
+            continue
+        module_dir = Path(module_file).resolve().parent
+        lib_dir = module_dir / "lib"
+        if lib_dir.exists():
+            _prepend_ld_library_path(lib_dir)
+            discovered_lib_dirs.append(lib_dir)
+
+    try:
+        venv_dir = Path(sys.executable).resolve().parents[1]
+        local_root = venv_dir / ".local"
+        for cuda_home in sorted(local_root.glob("cuda-*/usr/local/cuda-*")):
+            for lib_dir in (
+                cuda_home / "targets" / "x86_64-linux" / "lib",
+                cuda_home / "lib64",
+            ):
+                if lib_dir.exists():
+                    _prepend_ld_library_path(lib_dir)
+                    discovered_lib_dirs.append(lib_dir)
+    except Exception:
+        pass
+
+    try:
+        import rdkit
+
+        rdkit_pkg_dir = Path(rdkit.__file__).resolve().parent
+        rdkit_libs_dir = rdkit_pkg_dir.parent / "rdkit.libs"
+        if rdkit_libs_dir.exists():
+            _prepend_ld_library_path(rdkit_libs_dir)
+            for candidate in sorted(rdkit_libs_dir.glob("libRDKit*.so*")):
+                try:
+                    ctypes.CDLL(str(candidate), mode=ctypes.RTLD_GLOBAL)
+                except Exception:
+                    continue
+            for candidate in sorted(rdkit_libs_dir.glob("libboost_python*.so*")):
+                try:
+                    ctypes.CDLL(str(candidate), mode=ctypes.RTLD_GLOBAL)
+                    break
+                except Exception:
+                    continue
+        for candidate in sorted(rdkit_pkg_dir.rglob("*.so")):
+            try:
+                ctypes.CDLL(str(candidate), mode=ctypes.RTLD_GLOBAL)
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    for lib_dir in discovered_lib_dirs:
+        for lib_name in ("libcudart.so.12", "libnvrtc.so.12"):
+            candidate = lib_dir / lib_name
+            if candidate.exists():
+                try:
+                    ctypes.CDLL(str(candidate), mode=ctypes.RTLD_GLOBAL)
+                except Exception:
+                    pass
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate conformers with nvMolKit in isolated process")
+    parser.add_argument("--input-sdf", required=True)
+    parser.add_argument("--params-json", required=True)
+    parser.add_argument("--output-sdf", required=True)
+    parser.add_argument("--meta-json", required=True)
+    return parser.parse_args()
+
+
+def _write_meta(meta_path: Path, payload: dict):
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+
+def _read_input_molecules(input_sdf: Path):
+    supplier = Chem.SDMolSupplier(str(input_sdf), sanitize=False, removeHs=False)
+    molecules = []
+    names = []
+    valid_mask = []
+    invalid_count = 0
+    for idx, mol in enumerate(supplier):
+        if mol is None:
+            continue
+        uid = mol.GetProp("_Name") if mol.HasProp("_Name") else f"mol_{idx}"
+        if not uid.strip():
+            uid = f"mol_{idx}"
+        current = Chem.Mol(mol)
+        current.SetProp("_Name", uid)
+        try:
+            Chem.SanitizeMol(current)
+            current.RemoveAllConformers()
+            valid_mask.append(True)
+        except Exception:
+            invalid_count += 1
+            valid_mask.append(False)
+        molecules.append(current)
+        names.append(uid)
+    return molecules, names, valid_mask, invalid_count
+
+
+def _ensure_minimum_conformers(mol, confs_per_mol: int, seed: int | None):
+    target = max(1, int(confs_per_mol))
+    if mol.GetNumConformers() >= target:
+        return False
+
+    before = mol.GetNumConformers()
+
+    if mol.GetNumConformers() == 0:
+        conf = Chem.Conformer(mol.GetNumAtoms())
+        for atom_idx in range(mol.GetNumAtoms()):
+            conf.SetAtomPosition(atom_idx, Point3D(0.0, 0.0, 0.0))
+        mol.AddConformer(conf, assignId=True)
+
+    return mol.GetNumConformers() != before
+
+
+def _drop_non_finite_conformers(mol):
+    bad_ids = []
+    for cid in range(mol.GetNumConformers()):
+        conf = mol.GetConformer(cid)
+        ok = True
+        for atom_idx in range(conf.GetNumAtoms()):
+            pos = conf.GetAtomPosition(atom_idx)
+            if not (math.isfinite(pos.x) and math.isfinite(pos.y) and math.isfinite(pos.z)):
+                ok = False
+                break
+        if not ok:
+            bad_ids.append(cid)
+    for cid in reversed(bad_ids):
+        mol.RemoveConformer(cid)
+    return len(bad_ids)
+
+
+def _write_output_molecules(output_sdf: Path, molecules, names, confs_per_mol: int):
+    writer = Chem.SDWriter(str(output_sdf))
+    writer.SetKekulize(False)
+    written = 0
+    for uid, mol in zip(names, molecules):
+        count = min(int(confs_per_mol), mol.GetNumConformers())
+        for cid in range(count):
+            out = Chem.Mol(mol)
+            conf = mol.GetConformer(cid)
+            out.RemoveAllConformers()
+            out.AddConformer(conf, assignId=True)
+            out.SetProp("_Name", uid)
+            out.SetProp("conf_id", str(cid))
+            out.SetProp("ID", f"conformer_{cid}")
+            writer.write(out)
+            written += 1
+    writer.close()
+    return written
+
+
+def main():
+    args = parse_args()
+    input_sdf = Path(args.input_sdf)
+    params_json = Path(args.params_json)
+    output_sdf = Path(args.output_sdf)
+    meta_json = Path(args.meta_json)
+
+    started_at = time.time()
+    try:
+        _prepare_runtime()
+
+        with open(params_json, "r", encoding="utf-8") as f:
+            params = json.load(f)
+
+        confs_per_mol = int(params.get("confs_per_mol", 1))
+        seed = params.get("seed")
+        optimize = bool(params.get("optimize", True))
+        chunk_size = max(1, int(params.get("chunk_size", 128)))
+
+        molecules, names, valid_mask, invalid_count = _read_input_molecules(input_sdf)
+        if not molecules:
+            _write_meta(
+                meta_json,
+                {
+                    "ok": True,
+                    "elapsed_sec": time.time() - started_at,
+                    "input_molecules": 0,
+                    "written_conformers": 0,
+                    "errors": [],
+                },
+            )
+            output_sdf.parent.mkdir(parents=True, exist_ok=True)
+            output_sdf.write_text("", encoding="utf-8")
+            return 0
+
+        valid_indices = [i for i, ok in enumerate(valid_mask) if ok]
+        if valid_indices:
+            valid_molecules = [molecules[i] for i in valid_indices]
+
+            from nvmolkit.embedMolecules import EmbedMolecules as nvMolKitEmbed  # type: ignore
+            from nvmolkit.mmffOptimization import (  # type: ignore
+                MMFFOptimizeMoleculesConfs as nvMolKitMMFFOptimize,
+            )
+            from nvmolkit.types import HardwareOptions  # type: ignore
+
+            params_embed = ETKDGv3()
+            params_embed.useRandomCoords = True
+            if seed is not None:
+                params_embed.randomSeed = int(seed)
+
+            embed_hw = HardwareOptions(
+                preprocessingThreads=2,
+                batchSize=min(chunk_size, len(valid_molecules)),
+                batchesPerGpu=2,
+            )
+            nvMolKitEmbed(
+                molecules=valid_molecules,
+                params=params_embed,
+                confsPerMolecule=confs_per_mol,
+                maxIterations=-1,
+                hardwareOptions=embed_hw,
+            )
+
+            if optimize:
+                mmff_hw = HardwareOptions(preprocessingThreads=4, batchSize=0)
+                nvMolKitMMFFOptimize(
+                    molecules=valid_molecules,
+                    maxIters=200,
+                    nonBondedThreshold=100.0,
+                    hardwareOptions=mmff_hw,
+                )
+
+        fallback_generated = 0
+        dropped_bad_confs = 0
+        for mol in molecules:
+            dropped_bad_confs += _drop_non_finite_conformers(mol)
+            if _ensure_minimum_conformers(mol, confs_per_mol=confs_per_mol, seed=seed):
+                fallback_generated += 1
+
+        output_sdf.parent.mkdir(parents=True, exist_ok=True)
+        written_conformers = _write_output_molecules(output_sdf, molecules, names, confs_per_mol)
+
+        _write_meta(
+            meta_json,
+            {
+                "ok": True,
+                "elapsed_sec": time.time() - started_at,
+                "input_molecules": len(molecules),
+                "written_conformers": written_conformers,
+                "invalid_input_molecules": invalid_count,
+                "fallback_generated_molecules": fallback_generated,
+                "dropped_non_finite_conformers": dropped_bad_confs,
+                "errors": [],
+            },
+        )
+        return 0
+    except Exception as exc:
+        _write_meta(
+            meta_json,
+            {
+                "ok": False,
+                "elapsed_sec": time.time() - started_at,
+                "error": str(exc),
+                "traceback": traceback.format_exc(),
+            },
+        )
+        print(f"nvmolkit worker failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/matcha_nvmolkit_worker/src/matcha_nvmolkit_worker/cli.py
+++ b/packages/matcha_nvmolkit_worker/src/matcha_nvmolkit_worker/cli.py
@@ -119,7 +119,6 @@ def _read_input_molecules(input_sdf: Path):
     molecules = []
     names = []
     valid_mask = []
-    invalid_count = 0
     for idx, mol in enumerate(supplier):
         if mol is None:
             continue
@@ -133,41 +132,39 @@ def _read_input_molecules(input_sdf: Path):
             current.RemoveAllConformers()
             valid_mask.append(True)
         except Exception:
-            invalid_count += 1
             valid_mask.append(False)
         molecules.append(current)
         names.append(uid)
+    invalid_count = valid_mask.count(False)
     return molecules, names, valid_mask, invalid_count
 
 
 def _ensure_minimum_conformers(mol, confs_per_mol: int, seed: int | None):
-    target = max(1, int(confs_per_mol))
-    if mol.GetNumConformers() >= target:
+    if mol.GetNumConformers() >= max(1, int(confs_per_mol)):
+        return False
+    if mol.GetNumConformers() > 0:
         return False
 
-    before = mol.GetNumConformers()
+    conf = Chem.Conformer(mol.GetNumAtoms())
+    for atom_idx in range(mol.GetNumAtoms()):
+        conf.SetAtomPosition(atom_idx, Point3D(0.0, 0.0, 0.0))
+    mol.AddConformer(conf, assignId=True)
+    return True
 
-    if mol.GetNumConformers() == 0:
-        conf = Chem.Conformer(mol.GetNumAtoms())
-        for atom_idx in range(mol.GetNumAtoms()):
-            conf.SetAtomPosition(atom_idx, Point3D(0.0, 0.0, 0.0))
-        mol.AddConformer(conf, assignId=True)
 
-    return mol.GetNumConformers() != before
+def _conf_has_finite_coords(conf) -> bool:
+    for atom_idx in range(conf.GetNumAtoms()):
+        pos = conf.GetAtomPosition(atom_idx)
+        if not (math.isfinite(pos.x) and math.isfinite(pos.y) and math.isfinite(pos.z)):
+            return False
+    return True
 
 
 def _drop_non_finite_conformers(mol):
-    bad_ids = []
-    for cid in range(mol.GetNumConformers()):
-        conf = mol.GetConformer(cid)
-        ok = True
-        for atom_idx in range(conf.GetNumAtoms()):
-            pos = conf.GetAtomPosition(atom_idx)
-            if not (math.isfinite(pos.x) and math.isfinite(pos.y) and math.isfinite(pos.z)):
-                ok = False
-                break
-        if not ok:
-            bad_ids.append(cid)
+    bad_ids = [
+        cid for cid in range(mol.GetNumConformers())
+        if not _conf_has_finite_coords(mol.GetConformer(cid))
+    ]
     for cid in reversed(bad_ids):
         mol.RemoveConformer(cid)
     return len(bad_ids)

--- a/scripts/nvmolkit_worker.py
+++ b/scripts/nvmolkit_worker.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Compatibility wrapper for the packaged worker entrypoint."""
+
+import sys
+
+
+def _main() -> int:
+    try:
+        from matcha_nvmolkit_worker.cli import main
+    except Exception as exc:
+        print(
+            "Failed to import matcha_nvmolkit_worker package. "
+            "Run: uv run python scripts/setup_nvmolkit_worker.py",
+            file=sys.stderr,
+        )
+        print(f"Import error: {exc}", file=sys.stderr)
+        return 1
+    return int(main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/setup_nvmolkit_worker.py
+++ b/scripts/setup_nvmolkit_worker.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""Set up an isolated nvMolKit-based conformer worker environment.
+
+This script creates `.venv-nvmolkit-worker/` in the repository root and installs
+nvMolKit + build prerequisites into that virtual environment.
+It also installs the local `matcha-nvmolkit-worker` package into that env.
+
+Notes:
+  - This is intended to run on Linux with NVIDIA drivers (e.g. Kolmogorov).
+  - The main Matcha environment stays unchanged; Matcha will auto-discover the
+    worker at `.venv-nvmolkit-worker/bin/python scripts/nvmolkit_worker.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import gzip
+import urllib.request
+from pathlib import Path
+
+
+def _run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
+    print(f"+ {shlex.join(cmd)}", flush=True)
+    subprocess.run(cmd, cwd=str(cwd), env=env, check=True)
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    return venv_dir / "bin" / "python"
+
+
+def _uv_pip_install(
+    python: Path,
+    packages: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    upgrade: bool = False,
+) -> None:
+    cmd = ["uv", "pip", "install", "--python", str(python)]
+    if upgrade:
+        cmd.append("-U")
+    cmd.extend(packages)
+    _run(cmd, cwd=cwd, env=env)
+
+
+def _site_packages(python: Path, repo_root: Path) -> Path:
+    code = "import site; print(site.getsitepackages()[0])"
+    out = subprocess.check_output([str(python), "-c", code], cwd=str(repo_root), text=True).strip()
+    return Path(out)
+
+
+def _cmake_bin_dir(python: Path, repo_root: Path) -> Path | None:
+    """Return directory that contains the real `cmake` binary from the pip package."""
+    code = r"""
+from pathlib import Path
+import cmake
+
+root = Path(cmake.__file__).resolve().parent
+bin_dir = root / "data" / "bin"
+print(str(bin_dir))
+"""
+    try:
+        out = subprocess.check_output([str(python), "-c", code], cwd=str(repo_root), text=True).strip()
+    except Exception:
+        return None
+    p = Path(out)
+    if (p / "cmake").exists():
+        return p
+    return None
+
+
+def _make_rdkit_lib_symlink_farm(python: Path, repo_root: Path, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for p in out_dir.iterdir():
+        if p.is_symlink() or p.is_file():
+            p.unlink()
+
+    code = r"""
+import pathlib
+import rdkit
+
+pkg_dir = pathlib.Path(rdkit.__file__).resolve().parent
+so_files = sorted(pkg_dir.rglob("*.so"))
+print("\n".join(str(p) for p in so_files))
+"""
+    so_list = subprocess.check_output([str(python), "-c", code], cwd=str(repo_root), text=True)
+    so_paths = [Path(line.strip()) for line in so_list.splitlines() if line.strip()]
+    for src in so_paths:
+        dst = out_dir / src.name
+        if dst.exists():
+            continue
+        dst.symlink_to(src)
+
+    # Validate: nvMolKit build expects only files in this directory.
+    non_files = [p for p in out_dir.iterdir() if not p.is_file()]
+    if non_files:
+        raise RuntimeError(f"Unexpected non-files in RDKit lib dir: {non_files[:3]}")
+    return out_dir
+
+
+def _find_include_dir(python: Path, repo_root: Path, module_name: str) -> Path:
+    code = (
+        "import importlib, pathlib; "
+        f"m=importlib.import_module({module_name!r}); "
+        "p=pathlib.Path(m.__file__).resolve().parent/'include'; "
+        "print(str(p))"
+    )
+    out = subprocess.check_output([str(python), "-c", code], cwd=str(repo_root), text=True).strip()
+    inc = Path(out)
+    if not inc.exists():
+        raise RuntimeError(f"Include dir not found for {module_name}: {inc}")
+    # `rdkit-headers` wheels vendor headers under `include/rdkit/...`, while many
+    # CMake projects expect `GraphMol/...` directly in the include path.
+    if (inc / "rdkit" / "GraphMol").exists() and not (inc / "GraphMol").exists():
+        return inc / "rdkit"
+    return inc
+
+
+def _find_cuda_toolkit_root(python: Path, repo_root: Path) -> Path:
+    """Best-effort CUDA toolkit root discovery.
+
+    Tries:
+      1) `nvcc` in PATH (system/toolkit install)
+      2) `nvidia.cuda_nvcc` package directory (pip-based CUDA components)
+    """
+    code = r"""
+import shutil
+from pathlib import Path
+
+nvcc = shutil.which("nvcc")
+if nvcc:
+    p = Path(nvcc).resolve()
+    print(str(p.parent.parent))
+    raise SystemExit(0)
+
+try:
+    import nvidia.cuda_nvcc as m  # type: ignore
+except Exception as e:
+    raise SystemExit("CUDA toolkit not found (no nvcc in PATH, no nvidia.cuda_nvcc module)") from e
+
+module_dir = Path(m.__file__).resolve().parent
+print(str(module_dir))
+"""
+    out = subprocess.check_output([str(python), "-c", code], cwd=str(repo_root), text=True).strip()
+    root = Path(out)
+    if not root.exists():
+        raise RuntimeError(f"CUDA toolkit root does not exist: {root}")
+    return root
+
+
+def _os_release_id(repo_root: Path) -> tuple[str, str]:
+    path = Path("/etc/os-release")
+    if not path.exists():
+        return ("", "")
+    data = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    kv = {}
+    for line in data:
+        if "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        kv[k.strip()] = v.strip().strip('"')
+    return (kv.get("ID", ""), kv.get("VERSION_ID", ""))
+
+
+def _parse_cuda_repo_packages(repo_url: str) -> dict[str, str]:
+    """Return mapping package_name -> deb relative filename from NVIDIA CUDA repo."""
+    pkgs_gz = f"{repo_url.rstrip('/')}/Packages.gz"
+    with urllib.request.urlopen(pkgs_gz) as r:
+        raw = r.read()
+    text = gzip.decompress(raw).decode("utf-8", errors="replace")
+    package = None
+    filename = None
+    mapping: dict[str, str] = {}
+    for line in text.splitlines():
+        if line.startswith("Package: "):
+            package = line.split(":", 1)[1].strip()
+            filename = None
+        elif line.startswith("Filename: ") and package is not None:
+            filename = line.split(":", 1)[1].strip()
+            if filename.startswith("./"):
+                filename = filename[2:]
+            mapping[package] = filename
+        elif not line.strip():
+            package = None
+            filename = None
+    return mapping
+
+
+def _download(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists() and dest.stat().st_size > 0:
+        return
+    print(f"+ download {url} -> {dest}", flush=True)
+    with urllib.request.urlopen(url) as r:
+        data = r.read()
+    dest.write_bytes(data)
+
+
+def _extract_deb(deb_path: Path, extract_root: Path) -> None:
+    extract_root.mkdir(parents=True, exist_ok=True)
+    if shutil.which("dpkg-deb") is None:
+        raise RuntimeError(
+            "dpkg-deb is required to extract CUDA .deb packages but was not found in PATH. "
+            "Install it via your system package manager (e.g. apt install dpkg) or ensure "
+            "a full CUDA toolkit is available so the .deb fallback is not needed."
+        )
+    _run(["dpkg-deb", "-x", str(deb_path), str(extract_root)], cwd=extract_root)
+
+
+def _cuda_has_required_libs(cuda_root: Path) -> bool:
+    """Return True if the toolkit root looks complete enough for nvMolKit builds.
+
+    We primarily need cuSolver (CMake target CUDA::cusolver) and its common deps.
+    Pip-provided nvcc packages may not include these shared libraries.
+    """
+    required_globs = [
+        "**/libcusolver.so*",
+        "**/libcublas.so*",
+        "**/libcusparse.so*",
+        "**/libcudart.so*",
+    ]
+    for pat in required_globs:
+        if not any(cuda_root.glob(pat)):
+            return False
+    return True
+
+
+def _symlink_cuda_libs_into_toolkit(cuda_root: Path, extract_root: Path, *, cuda_ver: str) -> None:
+    """Make a user-space extracted toolkit discoverable by FindCUDAToolkit.
+
+    Some CUDA Debian packages place shared libraries under `usr/lib/x86_64-linux-gnu`
+    rather than directly under the toolkit root. CMake's FindCUDAToolkit expects
+    libraries under the toolkit root, so we symlink the common CUDA libs into
+    `targets/x86_64-linux/lib` when needed.
+    """
+    src_dirs = [
+        extract_root / "usr" / "lib" / "x86_64-linux-gnu",
+        extract_root / "usr" / "local" / f"cuda-{cuda_ver}" / "lib64",
+    ]
+    dst_dir = cuda_root / "targets" / "x86_64-linux" / "lib"
+    dst_dir.mkdir(parents=True, exist_ok=True)
+
+    patterns = [
+        "libcublas.so*",
+        "libcusolver.so*",
+        "libcusparse.so*",
+        "libcurand.so*",
+        "libcufft.so*",
+        "libnvrtc.so*",
+        "libcudart.so*",
+    ]
+    for src_dir in src_dirs:
+        if not src_dir.exists():
+            continue
+        for pat in patterns:
+            for src in src_dir.glob(pat):
+                if not src.is_file():
+                    continue
+                dst = dst_dir / src.name
+                if dst.exists():
+                    continue
+                try:
+                    dst.symlink_to(src)
+                except FileExistsError:
+                    continue
+
+
+def _rdkit_version_tuple(python: Path, repo_root: Path) -> tuple[int, int, int]:
+    code = "import rdkit; print(rdkit.__version__)"
+    out = subprocess.check_output([str(python), "-c", code], cwd=str(repo_root), text=True).strip()
+    parts = out.split(".")
+    if len(parts) < 3:
+        raise RuntimeError(f"Unexpected RDKit version string: {out!r}")
+    try:
+        year = int(parts[0])
+        month = int(parts[1])
+        rev = int(parts[2])
+    except ValueError as e:
+        raise RuntimeError(f"Unexpected RDKit version string: {out!r}") from e
+    return (year, month, rev)
+
+
+def _patch_rdkit_versions_header(*, rdkit_incdir: Path, python: Path, repo_root: Path) -> None:
+    """Patch rdkit-headers placeholder versions.h into a configured header.
+
+    The `rdkit-headers` wheel ships `RDGeneral/versions.h` with CMake placeholders
+    like `@RDKit_Year @`, which breaks C++ compilation. We rewrite the file with
+    concrete values based on the installed Python RDKit version.
+    """
+    versions_h = rdkit_incdir / "RDGeneral" / "versions.h"
+    if not versions_h.exists():
+        raise RuntimeError(f"RDKit versions header not found: {versions_h}")
+    text = versions_h.read_text(encoding="utf-8", errors="ignore")
+    if "@RDKit_Year" not in text:
+        return
+
+    year, month, rev = _rdkit_version_tuple(python, repo_root)
+    patched = f"""// Autogenerated by Matcha: scripts/setup_nvmolkit_worker.py
+// This file replaces unconfigured CMake placeholders shipped in rdkit-headers wheels.
+
+#pragma once
+
+#include <RDGeneral/export.h>
+
+// Version check macro
+// Can be used like: #if (RDKIT_VERSION >= RDKIT_VERSION_CHECK(2018, 3, 1))
+#define RDKIT_VERSION_CHECK(year, month, rev) ((year * 1000) + (month * 10) + (rev))
+
+#define RDKIT_VERSION_MAJOR {year}
+#define RDKIT_VERSION_MINOR {month}
+#define RDKIT_VERSION_PATCH {rev}
+
+// RDKIT_VERSION is (year*1000) + (month*10) + (rev)
+#define RDKIT_VERSION RDKIT_VERSION_CHECK(RDKIT_VERSION_MAJOR, RDKIT_VERSION_MINOR, RDKIT_VERSION_PATCH)
+
+namespace RDKit {{
+RDKIT_RDGENERAL_EXPORT extern const char* rdkitVersion;
+RDKIT_RDGENERAL_EXPORT extern const char* boostVersion;
+RDKIT_RDGENERAL_EXPORT extern const char* rdkitBuild;
+}}  // namespace RDKit
+"""
+    versions_h.write_text(patched, encoding="utf-8")
+    print(f"[matcha] patched RDKit versions header: {versions_h}", flush=True)
+
+
+def _prepare_nvmolkit_source(*, venv_dir: Path, repo_root: Path, ref: str) -> Path:
+    """Clone nvMolKit source (not vendored) and apply minimal build patches.
+
+    We patch nvMolKit's pip-RDKit build to use the C++11 ABI, matching pip RDKit
+    wheels on modern Linux distros.
+    """
+    src_root = venv_dir / ".cache" / "matcha" / "nvmolkit_src"
+    if src_root.exists():
+        shutil.rmtree(src_root)
+    src_root.parent.mkdir(parents=True, exist_ok=True)
+
+    # Tags like `v0.4.0` are supported by `--branch`.
+    _run(
+        [
+            "git",
+            "clone",
+            "--filter=blob:none",
+            "--depth",
+            "1",
+            "--branch",
+            ref,
+            "https://github.com/NVIDIA-Digital-Bio/nvMolKit",
+            str(src_root),
+        ],
+        cwd=repo_root,
+    )
+
+    host_flags = src_root / "cmake" / "host_compiler_flags.cmake"
+    if not host_flags.exists():
+        raise RuntimeError(f"nvMolKit file not found: {host_flags}")
+    text = host_flags.read_text(encoding="utf-8", errors="ignore")
+    text = text.replace('message(STATUS "Using pre-cxx11 ABI")', 'message(STATUS "Using C++11 ABI")')
+    text = text.replace(
+        "add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)",
+        "add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=1)",
+    )
+    host_flags.write_text(text, encoding="utf-8")
+    return src_root
+
+
+def _ensure_nvcc_from_nvidia_debs(*, venv_dir: Path, repo_root: Path, cuda_ver: str = "12.8") -> Path:
+    """Install a user-space CUDA toolkit by downloading NVIDIA .deb packages."""
+    os_id, os_ver = _os_release_id(repo_root)
+    if os_id != "ubuntu":
+        raise RuntimeError(f"Unsupported OS for auto nvcc download: {os_id} {os_ver}")
+
+    # Only implement the known-good path for Ubuntu 24.04 (noble) used on Kolmogorov.
+    if not os_ver.startswith("24.04"):
+        raise RuntimeError(f"Unsupported Ubuntu version for auto nvcc download: {os_ver}")
+
+    repo_url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64"
+    pkg_to_file = _parse_cuda_repo_packages(repo_url)
+
+    # Pick a stable set of packages that provides nvcc + the CUDA math libraries
+    # required by nvMolKit (cuSolver + deps).
+    suffix = "12-8"
+    required = [
+        f"cuda-nvcc-{suffix}",
+        f"cuda-nvvm-{suffix}",
+        f"cuda-crt-{suffix}",
+        f"cuda-cccl-{suffix}",
+        f"cuda-cudart-{suffix}",
+        f"cuda-cudart-dev-{suffix}",
+        f"cuda-nvrtc-{suffix}",
+        f"cuda-nvrtc-dev-{suffix}",
+        f"cuda-nvtx-{suffix}",
+        f"cuda-driver-dev-{suffix}",
+        f"libcublas-{suffix}",
+        f"libcublas-dev-{suffix}",
+        f"libcusolver-{suffix}",
+        f"libcusolver-dev-{suffix}",
+        f"libcusparse-{suffix}",
+        f"libcusparse-dev-{suffix}",
+        f"libcurand-{suffix}",
+        f"libcurand-dev-{suffix}",
+        f"libcufft-{suffix}",
+        f"libcufft-dev-{suffix}",
+        f"cuda-toolkit-{suffix}-config-common",
+        "cuda-toolkit-12-config-common",
+        "cuda-toolkit-config-common",
+    ]
+
+    cache_dir = venv_dir / ".cache" / "matcha" / "cuda_debs"
+    extract_root = venv_dir / ".local" / f"cuda-{cuda_ver}"
+    for pkg in required:
+        rel = pkg_to_file.get(pkg)
+        if rel is None:
+            raise RuntimeError(f"CUDA repo package not found: {pkg}")
+        url = f"{repo_url}/{rel}"
+        deb_path = cache_dir / Path(rel).name
+        _download(url, deb_path)
+        _extract_deb(deb_path, extract_root)
+
+    cuda_home = extract_root / "usr" / "local" / f"cuda-{cuda_ver}"
+    _symlink_cuda_libs_into_toolkit(cuda_home, extract_root, cuda_ver=cuda_ver)
+    nvcc = cuda_home / "bin" / "nvcc"
+    if not nvcc.exists():
+        raise RuntimeError(f"nvcc not found after extraction: {nvcc}")
+    if not _cuda_has_required_libs(cuda_home):
+        raise RuntimeError(f"Extracted CUDA toolkit is missing required shared libraries: {cuda_home}")
+    return cuda_home
+
+
+def _smoke_worker(python: Path, repo_root: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="matcha_nvmolkit_worker_smoke_") as tmp:
+        tmp_dir = Path(tmp)
+        input_sdf = tmp_dir / "input.sdf"
+        params_json = tmp_dir / "params.json"
+        output_sdf = tmp_dir / "output.sdf"
+        meta_json = tmp_dir / "meta.json"
+
+        # Generate input SDF in the worker env (RDKit is installed there).
+        gen = r"""
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+writer = Chem.SDWriter(r""" + repr(str(input_sdf)) + r""")
+writer.SetKekulize(False)
+for i, smi in enumerate(["CCO", "c1ccccc1"]):
+    mol = Chem.AddHs(Chem.MolFromSmiles(smi))
+    AllChem.EmbedMolecule(mol, AllChem.ETKDGv3())
+    mol.SetProp("_Name", f"mol_{i}")
+    writer.write(mol)
+writer.close()
+"""
+        _run([str(python), "-c", gen], cwd=repo_root)
+        params_json.write_text(
+            json.dumps({"confs_per_mol": 2, "seed": 1, "optimize": True, "chunk_size": 32}, indent=2),
+            encoding="utf-8",
+        )
+
+        _run(
+            [
+                str(python),
+                "-m",
+                "matcha_nvmolkit_worker.cli",
+                "--input-sdf",
+                str(input_sdf),
+                "--params-json",
+                str(params_json),
+                "--output-sdf",
+                str(output_sdf),
+                "--meta-json",
+                str(meta_json),
+            ],
+            cwd=repo_root,
+        )
+        meta = json.loads(meta_json.read_text(encoding="utf-8"))
+        if not meta.get("ok"):
+            raise RuntimeError(f"Worker smoke failed: {meta}")
+        written = int(meta.get("written_conformers", 0))
+        if written < 2:
+            raise RuntimeError(f"Worker smoke produced too few conformers: {meta}")
+        print(f"[ok] worker smoke: written_conformers={written}", flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Set up isolated nvMolKit conformer worker env")
+    parser.add_argument(
+        "--venv-dir",
+        default=".venv-nvmolkit-worker",
+        help="Worker venv directory (relative to repo root). Default: .venv-nvmolkit-worker",
+    )
+    parser.add_argument(
+        "--nvMolKit-ref",
+        default="v0.4.0",
+        help="Git ref to install nvMolKit from. Default: v0.4.0",
+    )
+    parser.add_argument(
+        "--skip-smoke",
+        action="store_true",
+        help="Skip running the post-install worker smoke test.",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    venv_dir = (repo_root / args.venv_dir).resolve()
+
+    if not sys.platform.startswith("linux"):
+        print(
+            "ERROR: scripts/setup_nvmolkit_worker.py is intended to run on Linux with an NVIDIA GPU.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if shutil.which("uv") is None:
+        print("ERROR: uv is required but not found in PATH.", file=sys.stderr)
+        return 2
+
+    print(f"[matcha] repo_root: {repo_root}", flush=True)
+    print(f"[matcha] worker_venv: {venv_dir}", flush=True)
+
+    # Create venv
+    _run(["uv", "venv", "--seed", "--clear", str(venv_dir)], cwd=repo_root)
+    python = _venv_python(venv_dir)
+    if not python.exists():
+        print(f"ERROR: venv python not found: {python}", file=sys.stderr)
+        return 2
+
+    # Install build tools + runtime deps in worker venv via uv.
+    _uv_pip_install(
+        python,
+        ["pip", "setuptools", "wheel"],
+        cwd=repo_root,
+        upgrade=True,
+    )
+    _uv_pip_install(
+        python,
+        ["cmake", "ninja", "scikit-build", "pybind11"],
+        cwd=repo_root,
+        upgrade=True,
+    )
+
+    # Worker env is isolated, so we can pin versions without affecting Matcha.
+    _uv_pip_install(
+        python,
+        [
+            "rdkit==2025.09.3",
+            "rdkit-headers==2025.9.3.post1",
+            "boost-headers==1.81.0",
+            "nvidia-cuda-nvcc-cu12==12.8.*",
+        ],
+        cwd=repo_root,
+    )
+
+    rdkit_libdir = venv_dir / ".cache" / "matcha" / "rdkit_pip_libs"
+    _make_rdkit_lib_symlink_farm(python, repo_root, rdkit_libdir)
+    rdkit_incdir = _find_include_dir(python, repo_root, "rdkit_headers")
+    _patch_rdkit_versions_header(rdkit_incdir=rdkit_incdir, python=python, repo_root=repo_root)
+    boost_incdir = _find_include_dir(python, repo_root, "boost_headers")
+    cuda_root = _find_cuda_toolkit_root(python, repo_root)
+    if not (cuda_root / "bin" / "nvcc").exists() or not _cuda_has_required_libs(cuda_root):
+        print(
+            "[matcha] CUDA toolkit is incomplete (missing nvcc and/or required CUDA libs); "
+            "downloading a user-space toolkit from NVIDIA .debs.",
+            flush=True,
+        )
+        cuda_root = _ensure_nvcc_from_nvidia_debs(venv_dir=venv_dir, repo_root=repo_root, cuda_ver="12.8")
+
+    env = os.environ.copy()
+    env["NVMOLKIT_BUILD_AGAINST_PIP_RDKIT"] = "1"
+    env["NVMOLKIT_BUILD_AGAINST_PIP_LIBDIR"] = str(rdkit_libdir)
+    env["NVMOLKIT_BUILD_AGAINST_PIP_INCDIR"] = str(rdkit_incdir)
+    env["NVMOLKIT_BUILD_AGAINST_PIP_BOOSTINCLUDEDIR"] = str(boost_incdir)
+    env["CUDA_HOME"] = str(cuda_root)
+    env["CUDAToolkit_ROOT"] = str(cuda_root)
+    cmake_bin = _cmake_bin_dir(python, repo_root)
+    cmake_prefix = f"{cmake_bin}:" if cmake_bin is not None else ""
+    env["PATH"] = f"{cmake_prefix}{venv_dir / 'bin'}:{cuda_root / 'bin'}:{env.get('PATH','')}"
+    year, month, rev = _rdkit_version_tuple(python, repo_root)
+    cmake_args = env.get("CMAKE_ARGS", "")
+    extra = (
+        f"-DRDKit_VERSION_MAJOR={year} -DRDKit_VERSION_MINOR={month} -DRDKit_VERSION_PATCH={rev} "
+    )
+    env["CMAKE_ARGS"] = f"{cmake_args} {extra}".strip()
+
+    worker_pkg = repo_root / "packages" / "matcha_nvmolkit_worker"
+    if not worker_pkg.exists():
+        raise RuntimeError(f"Worker package not found: {worker_pkg}")
+    _uv_pip_install(python, [str(worker_pkg)], cwd=repo_root)
+
+    nvmolkit_src = _prepare_nvmolkit_source(venv_dir=venv_dir, repo_root=repo_root, ref=args.nvMolKit_ref)
+    _uv_pip_install(python, [str(nvmolkit_src)], cwd=repo_root, env=env)
+
+    # Smoke test: run the worker end-to-end.
+    if not args.skip_smoke:
+        _smoke_worker(python, repo_root)
+
+    print("[ok] nvMolKit worker env is ready.", flush=True)
+    print(
+        "[matcha] Matcha will auto-discover the worker at "
+        f"{venv_dir}/bin/matcha-nvmolkit-worker when MATCHA_CONFORMER_BACKEND=auto.",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup_nvmolkit_worker.py
+++ b/scripts/setup_nvmolkit_worker.py
@@ -58,22 +58,16 @@ def _site_packages(python: Path, repo_root: Path) -> Path:
 
 def _cmake_bin_dir(python: Path, repo_root: Path) -> Path | None:
     """Return directory that contains the real `cmake` binary from the pip package."""
-    code = r"""
-from pathlib import Path
-import cmake
-
-root = Path(cmake.__file__).resolve().parent
-bin_dir = root / "data" / "bin"
-print(str(bin_dir))
-"""
+    code = (
+        "from pathlib import Path; import cmake; "
+        "print(Path(cmake.__file__).resolve().parent / 'data' / 'bin')"
+    )
     try:
         out = subprocess.check_output([str(python), "-c", code], cwd=str(repo_root), text=True).strip()
     except Exception:
         return None
     p = Path(out)
-    if (p / "cmake").exists():
-        return p
-    return None
+    return p if (p / "cmake").exists() else None
 
 
 def _make_rdkit_lib_symlink_farm(python: Path, repo_root: Path, out_dir: Path) -> Path:
@@ -98,7 +92,6 @@ print("\n".join(str(p) for p in so_files))
             continue
         dst.symlink_to(src)
 
-    # Validate: nvMolKit build expects only files in this directory.
     non_files = [p for p in out_dir.iterdir() if not p.is_file()]
     if non_files:
         raise RuntimeError(f"Unexpected non-files in RDKit lib dir: {non_files[:3]}")
@@ -109,15 +102,13 @@ def _find_include_dir(python: Path, repo_root: Path, module_name: str) -> Path:
     code = (
         "import importlib, pathlib; "
         f"m=importlib.import_module({module_name!r}); "
-        "p=pathlib.Path(m.__file__).resolve().parent/'include'; "
-        "print(str(p))"
+        "print(pathlib.Path(m.__file__).resolve().parent / 'include')"
     )
     out = subprocess.check_output([str(python), "-c", code], cwd=str(repo_root), text=True).strip()
     inc = Path(out)
     if not inc.exists():
         raise RuntimeError(f"Include dir not found for {module_name}: {inc}")
-    # `rdkit-headers` wheels vendor headers under `include/rdkit/...`, while many
-    # CMake projects expect `GraphMol/...` directly in the include path.
+    # rdkit-headers wheels vendor headers under include/rdkit/; CMake expects GraphMol/ directly.
     if (inc / "rdkit" / "GraphMol").exists() and not (inc / "GraphMol").exists():
         return inc / "rdkit"
     return inc
@@ -155,13 +146,12 @@ print(str(module_dir))
     return root
 
 
-def _os_release_id(repo_root: Path) -> tuple[str, str]:
+def _os_release_id() -> tuple[str, str]:
     path = Path("/etc/os-release")
     if not path.exists():
         return ("", "")
-    data = path.read_text(encoding="utf-8", errors="ignore").splitlines()
     kv = {}
-    for line in data:
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
         if "=" not in line:
             continue
         k, v = line.split("=", 1)
@@ -176,20 +166,15 @@ def _parse_cuda_repo_packages(repo_url: str) -> dict[str, str]:
         raw = r.read()
     text = gzip.decompress(raw).decode("utf-8", errors="replace")
     package = None
-    filename = None
     mapping: dict[str, str] = {}
     for line in text.splitlines():
         if line.startswith("Package: "):
             package = line.split(":", 1)[1].strip()
-            filename = None
         elif line.startswith("Filename: ") and package is not None:
-            filename = line.split(":", 1)[1].strip()
-            if filename.startswith("./"):
-                filename = filename[2:]
+            filename = line.split(":", 1)[1].strip().removeprefix("./")
             mapping[package] = filename
         elif not line.strip():
             package = None
-            filename = None
     return mapping
 
 
@@ -279,12 +264,9 @@ def _rdkit_version_tuple(python: Path, repo_root: Path) -> tuple[int, int, int]:
     if len(parts) < 3:
         raise RuntimeError(f"Unexpected RDKit version string: {out!r}")
     try:
-        year = int(parts[0])
-        month = int(parts[1])
-        rev = int(parts[2])
+        return (int(parts[0]), int(parts[1]), int(parts[2]))
     except ValueError as e:
         raise RuntimeError(f"Unexpected RDKit version string: {out!r}") from e
-    return (year, month, rev)
 
 
 def _patch_rdkit_versions_header(*, rdkit_incdir: Path, python: Path, repo_root: Path) -> None:
@@ -331,17 +313,12 @@ RDKIT_RDGENERAL_EXPORT extern const char* rdkitBuild;
 
 
 def _prepare_nvmolkit_source(*, venv_dir: Path, repo_root: Path, ref: str) -> Path:
-    """Clone nvMolKit source (not vendored) and apply minimal build patches.
-
-    We patch nvMolKit's pip-RDKit build to use the C++11 ABI, matching pip RDKit
-    wheels on modern Linux distros.
-    """
+    """Clone nvMolKit source and patch the build to use the C++11 ABI."""
     src_root = venv_dir / ".cache" / "matcha" / "nvmolkit_src"
     if src_root.exists():
         shutil.rmtree(src_root)
     src_root.parent.mkdir(parents=True, exist_ok=True)
 
-    # Tags like `v0.4.0` are supported by `--branch`.
     _run(
         [
             "git",
@@ -372,19 +349,16 @@ def _prepare_nvmolkit_source(*, venv_dir: Path, repo_root: Path, ref: str) -> Pa
 
 def _ensure_nvcc_from_nvidia_debs(*, venv_dir: Path, repo_root: Path, cuda_ver: str = "12.8") -> Path:
     """Install a user-space CUDA toolkit by downloading NVIDIA .deb packages."""
-    os_id, os_ver = _os_release_id(repo_root)
+    os_id, os_ver = _os_release_id()
     if os_id != "ubuntu":
         raise RuntimeError(f"Unsupported OS for auto nvcc download: {os_id} {os_ver}")
 
-    # Only implement the known-good path for Ubuntu 24.04 (noble) used on Kolmogorov.
     if not os_ver.startswith("24.04"):
         raise RuntimeError(f"Unsupported Ubuntu version for auto nvcc download: {os_ver}")
 
     repo_url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64"
     pkg_to_file = _parse_cuda_repo_packages(repo_url)
 
-    # Pick a stable set of packages that provides nvcc + the CUDA math libraries
-    # required by nvMolKit (cuSolver + deps).
     suffix = "12-8"
     required = [
         f"cuda-nvcc-{suffix}",
@@ -441,21 +415,20 @@ def _smoke_worker(python: Path, repo_root: Path) -> None:
         output_sdf = tmp_dir / "output.sdf"
         meta_json = tmp_dir / "meta.json"
 
-        # Generate input SDF in the worker env (RDKit is installed there).
-        gen = r"""
+        gen_script = f"""
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
-writer = Chem.SDWriter(r""" + repr(str(input_sdf)) + r""")
+writer = Chem.SDWriter({str(input_sdf)!r})
 writer.SetKekulize(False)
 for i, smi in enumerate(["CCO", "c1ccccc1"]):
     mol = Chem.AddHs(Chem.MolFromSmiles(smi))
     AllChem.EmbedMolecule(mol, AllChem.ETKDGv3())
-    mol.SetProp("_Name", f"mol_{i}")
+    mol.SetProp("_Name", f"mol_{{i}}")
     writer.write(mol)
 writer.close()
 """
-        _run([str(python), "-c", gen], cwd=repo_root)
+        _run([str(python), "-c", gen_script], cwd=repo_root)
         params_json.write_text(
             json.dumps({"confs_per_mol": 2, "seed": 1, "optimize": True, "chunk_size": 32}, indent=2),
             encoding="utf-8",
@@ -463,17 +436,11 @@ writer.close()
 
         _run(
             [
-                str(python),
-                "-m",
-                "matcha_nvmolkit_worker.cli",
-                "--input-sdf",
-                str(input_sdf),
-                "--params-json",
-                str(params_json),
-                "--output-sdf",
-                str(output_sdf),
-                "--meta-json",
-                str(meta_json),
+                str(python), "-m", "matcha_nvmolkit_worker.cli",
+                "--input-sdf", str(input_sdf),
+                "--params-json", str(params_json),
+                "--output-sdf", str(output_sdf),
+                "--meta-json", str(meta_json),
             ],
             cwd=repo_root,
         )
@@ -522,14 +489,12 @@ def main() -> int:
     print(f"[matcha] repo_root: {repo_root}", flush=True)
     print(f"[matcha] worker_venv: {venv_dir}", flush=True)
 
-    # Create venv
     _run(["uv", "venv", "--seed", "--clear", str(venv_dir)], cwd=repo_root)
     python = _venv_python(venv_dir)
     if not python.exists():
         print(f"ERROR: venv python not found: {python}", file=sys.stderr)
         return 2
 
-    # Install build tools + runtime deps in worker venv via uv.
     _uv_pip_install(
         python,
         ["pip", "setuptools", "wheel"],
@@ -543,7 +508,6 @@ def main() -> int:
         upgrade=True,
     )
 
-    # Worker env is isolated, so we can pin versions without affecting Matcha.
     _uv_pip_install(
         python,
         [
@@ -577,8 +541,8 @@ def main() -> int:
     env["CUDA_HOME"] = str(cuda_root)
     env["CUDAToolkit_ROOT"] = str(cuda_root)
     cmake_bin = _cmake_bin_dir(python, repo_root)
-    cmake_prefix = f"{cmake_bin}:" if cmake_bin is not None else ""
-    env["PATH"] = f"{cmake_prefix}{venv_dir / 'bin'}:{cuda_root / 'bin'}:{env.get('PATH','')}"
+    path_parts = [p for p in [cmake_bin, venv_dir / "bin", cuda_root / "bin"] if p is not None]
+    env["PATH"] = ":".join([str(p) for p in path_parts] + [env.get("PATH", "")])
     year, month, rev = _rdkit_version_tuple(python, repo_root)
     cmake_args = env.get("CMAKE_ARGS", "")
     extra = (
@@ -594,7 +558,6 @@ def main() -> int:
     nvmolkit_src = _prepare_nvmolkit_source(venv_dir=venv_dir, repo_root=repo_root, ref=args.nvMolKit_ref)
     _uv_pip_install(python, [str(nvmolkit_src)], cwd=repo_root, env=env)
 
-    # Smoke test: run the worker end-to-end.
     if not args.skip_smoke:
         _smoke_worker(python, repo_root)
 

--- a/tests/test_conformer_generation_batch.py
+++ b/tests/test_conformer_generation_batch.py
@@ -1,0 +1,24 @@
+import pytest
+from rdkit import Chem
+
+from matcha.utils.preprocessing import generate_conformer_mols_batch
+
+
+def test_generate_conformer_mols_batch_rdkit_shapes():
+    mols = [
+        Chem.MolFromSmiles("CCO"),
+        Chem.MolFromSmiles("c1ccccc1"),
+    ]
+    out = generate_conformer_mols_batch(mols, confs_per_mol=2, backend="rdkit", chunk_size=2)
+    assert len(out) == 2
+    assert all(len(x) == 2 for x in out)
+    assert all(m.GetNumConformers() == 1 for x in out for m in x)
+
+
+def test_generate_conformer_mols_batch_invalid_backend():
+    mols = [
+        Chem.MolFromSmiles("CCO"),
+        Chem.MolFromSmiles("c1ccccc1"),
+    ]
+    with pytest.raises(ValueError, match="Unknown conformer backend"):
+        generate_conformer_mols_batch(mols, confs_per_mol=2, backend="nvmolkit", chunk_size=2)

--- a/tests/test_conformer_generation_in_memory.py
+++ b/tests/test_conformer_generation_in_memory.py
@@ -1,0 +1,12 @@
+from rdkit import Chem
+
+from matcha.utils.preprocessing import generate_conformer_mols
+
+
+def test_generate_conformer_mols_returns_single_conformer_molecules():
+    mol = Chem.MolFromSmiles("CCO")
+    conformers = generate_conformer_mols(mol, num_conformers=3, backend="rdkit")
+
+    assert len(conformers) == 3
+    assert all(m.GetNumConformers() == 1 for m in conformers)
+    assert all(m.HasProp("ID") for m in conformers)

--- a/tests/test_conformer_worker_contract.py
+++ b/tests/test_conformer_worker_contract.py
@@ -1,5 +1,8 @@
 import json
+import multiprocessing
 import subprocess
+import threading
+import time
 from pathlib import Path
 
 import numpy as np
@@ -7,12 +10,23 @@ import pytest
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
-from matcha.utils.preprocessing import generate_conformer_mols_batch
+from matcha.utils.preprocessing import (
+    _auto_setup_worker_once,
+    _worker_setup_file_lock,
+    generate_conformer_mols_batch,
+)
 
 
 def _arg_value(cmd: list[str], flag: str) -> str:
     idx = cmd.index(flag)
     return cmd[idx + 1]
+
+
+def _hold_worker_lock(lock_path: str, shared_state, hold_seconds: float):
+    with _worker_setup_file_lock(Path(lock_path)):
+        shared_state.append(("enter", time.time()))
+        time.sleep(hold_seconds)
+        shared_state.append(("exit", time.time()))
 
 
 def _write_mock_worker_outputs(cmd: list[str], confs_per_mol: int = 2):
@@ -136,3 +150,84 @@ def test_auto_backend_falls_back_when_worker_returns_invalid_sdf(monkeypatch):
     assert out_mol.GetNumConformers() == 1
     coords = out_mol.GetConformer(0).GetPositions()
     assert np.isfinite(coords).all()
+
+
+def test_auto_setup_worker_once_reuses_successful_setup(monkeypatch, tmp_path):
+    state = {"ready": False, "calls": 0}
+
+    def fake_worker_command_configured():
+        return state["ready"]
+
+    def fake_run(cmd, cwd, check, capture_output, text, timeout):
+        state["calls"] += 1
+        time.sleep(0.1)
+        state["ready"] = True
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("matcha.utils.preprocessing._WORKER_AUTO_SETUP_ATTEMPTED", False)
+    monkeypatch.setattr("matcha.utils.preprocessing._WORKER_AUTO_SETUP_SUCCEEDED", False)
+    monkeypatch.setattr("matcha.utils.preprocessing._worker_command_configured", fake_worker_command_configured)
+    monkeypatch.setattr("matcha.utils.preprocessing.subprocess.run", fake_run)
+    monkeypatch.setattr("matcha.utils.preprocessing._env_flag", lambda *args, **kwargs: True)
+    monkeypatch.setattr("matcha.utils.preprocessing.shutil.which", lambda name: "/usr/bin/uv")
+    monkeypatch.setenv("MATCHA_CONFORMER_AUTO_SETUP_WORKER", "1")
+
+    repo_root = tmp_path / "repo"
+    setup_script = repo_root / "scripts" / "setup_nvmolkit_worker.py"
+    setup_script.parent.mkdir(parents=True, exist_ok=True)
+    setup_script.write_text("print('ok')\n", encoding="utf-8")
+
+    original_resolve = Path.resolve
+
+    def fake_resolve(path_self, *args, **kwargs):
+        if path_self.name == "preprocessing.py":
+            return repo_root / "matcha" / "utils" / "preprocessing.py"
+        return original_resolve(path_self, *args, **kwargs)
+
+    monkeypatch.setattr("pathlib.Path.resolve", fake_resolve)
+
+    results = []
+
+    def run_setup():
+        results.append(_auto_setup_worker_once())
+
+    threads = [threading.Thread(target=run_setup) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert results == [True, True]
+    assert state["calls"] == 1
+
+
+def test_worker_setup_file_lock_excludes_other_processes(tmp_path):
+    lock_path = tmp_path / "worker.setup.lock"
+    manager = multiprocessing.Manager()
+    events = manager.list()
+
+    processes = [
+        multiprocessing.Process(target=_hold_worker_lock, args=(str(lock_path), events, 0.2)),
+        multiprocessing.Process(target=_hold_worker_lock, args=(str(lock_path), events, 0.2)),
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=5)
+        assert process.exitcode == 0
+
+    event_list = list(events)
+    assert len(event_list) == 4
+
+    intervals = []
+    current_start = None
+    for event_type, timestamp in event_list:
+        if event_type == "enter":
+            current_start = timestamp
+        else:
+            intervals.append((current_start, timestamp))
+            current_start = None
+
+    assert len(intervals) == 2
+    intervals.sort()
+    assert intervals[1][0] >= intervals[0][1]

--- a/tests/test_conformer_worker_contract.py
+++ b/tests/test_conformer_worker_contract.py
@@ -1,0 +1,138 @@
+import json
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from matcha.utils.preprocessing import generate_conformer_mols_batch
+
+
+def _arg_value(cmd: list[str], flag: str) -> str:
+    idx = cmd.index(flag)
+    return cmd[idx + 1]
+
+
+def _write_mock_worker_outputs(cmd: list[str], confs_per_mol: int = 2):
+    input_sdf = Path(_arg_value(cmd, "--input-sdf"))
+    params_json = Path(_arg_value(cmd, "--params-json"))
+    output_sdf = Path(_arg_value(cmd, "--output-sdf"))
+    meta_json = Path(_arg_value(cmd, "--meta-json"))
+
+    with open(params_json, "r", encoding="utf-8") as f:
+        params = json.load(f)
+    assert params["confs_per_mol"] == confs_per_mol
+
+    supplier = Chem.SDMolSupplier(str(input_sdf), sanitize=True, removeHs=False)
+    writer = Chem.SDWriter(str(output_sdf))
+    writer.SetKekulize(False)
+    input_count = 0
+    output_count = 0
+    for mol in supplier:
+        assert mol is not None
+        input_count += 1
+        uid = mol.GetProp("_Name")
+        base = Chem.Mol(mol)
+        base = Chem.AddHs(base, addCoords=True)
+        params_embed = AllChem.ETKDGv3()
+        params_embed.randomSeed = 1
+        AllChem.EmbedMultipleConfs(base, confs_per_mol, params_embed)
+        for cid in range(min(confs_per_mol, base.GetNumConformers())):
+            out = Chem.Mol(base)
+            conf = base.GetConformer(cid)
+            out.RemoveAllConformers()
+            out.AddConformer(conf, assignId=True)
+            out.SetProp("_Name", uid)
+            out.SetProp("conf_id", str(cid))
+            writer.write(out)
+            output_count += 1
+    writer.close()
+
+    with open(meta_json, "w", encoding="utf-8") as f:
+        json.dump(
+            {"ok": True, "input_molecules": input_count, "written_conformers": output_count, "errors": []},
+            f,
+        )
+
+
+def test_worker_backend_contract_success(monkeypatch):
+    def fake_run(cmd, check, capture_output, text, timeout):
+        _write_mock_worker_outputs(cmd, confs_per_mol=2)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setenv("MATCHA_CONFORMER_WORKER_CMD", "fake_worker")
+    monkeypatch.setattr("matcha.utils.preprocessing.subprocess.run", fake_run)
+
+    mols = [Chem.MolFromSmiles("CCO"), Chem.MolFromSmiles("c1ccccc1")]
+    output = generate_conformer_mols_batch(mols, confs_per_mol=2, backend="worker", chunk_size=2)
+
+    assert len(output) == 2
+    assert all(len(conf_list) == 2 for conf_list in output)
+    assert all(mol.GetNumConformers() == 1 for conf_list in output for mol in conf_list)
+
+
+def test_worker_backend_fail_fast(monkeypatch):
+    def failing_run(cmd, check, capture_output, text, timeout):
+        return subprocess.CompletedProcess(cmd, 1, "", "mock worker failure")
+
+    monkeypatch.setenv("MATCHA_CONFORMER_WORKER_CMD", "fake_worker")
+    monkeypatch.setattr("matcha.utils.preprocessing.subprocess.run", failing_run)
+
+    mols = [Chem.MolFromSmiles("CCO")]
+    with pytest.raises(RuntimeError, match="Worker conformer generation failed"):
+        generate_conformer_mols_batch(mols, confs_per_mol=2, backend="worker", chunk_size=1)
+
+
+def test_auto_backend_fallback_to_rdkit(monkeypatch):
+    def failing_run(cmd, check, capture_output, text, timeout):
+        return subprocess.CompletedProcess(cmd, 1, "", "worker unavailable")
+
+    monkeypatch.setenv("MATCHA_CONFORMER_WORKER_CMD", "fake_worker")
+    monkeypatch.setattr("matcha.utils.preprocessing.subprocess.run", failing_run)
+
+    mols = [Chem.MolFromSmiles("CCO"), Chem.MolFromSmiles("CCN")]
+    output = generate_conformer_mols_batch(mols, confs_per_mol=2, backend="auto", chunk_size=2)
+
+    assert len(output) == 2
+    assert all(len(conf_list) >= 1 for conf_list in output)
+    assert all(mol.GetNumConformers() == 1 for conf_list in output for mol in conf_list)
+
+
+def test_auto_backend_falls_back_when_worker_returns_invalid_sdf(monkeypatch):
+    def fake_run(cmd, check, capture_output, text, timeout):
+        output_sdf = Path(_arg_value(cmd, "--output-sdf"))
+        meta_json = Path(_arg_value(cmd, "--meta-json"))
+        input_sdf = Path(_arg_value(cmd, "--input-sdf"))
+
+        supplier = Chem.SDMolSupplier(str(input_sdf), sanitize=False, removeHs=False)
+        writer = Chem.SDWriter(str(output_sdf))
+        writer.SetKekulize(False)
+        for mol in supplier:
+            assert mol is not None
+            uid = mol.GetProp("_Name")
+            out = Chem.Mol(mol)
+            conf = out.GetConformer(0)
+            conf.SetAtomPosition(0, (float("nan"), 0.0, 0.0))
+            out.SetProp("_Name", uid)
+            out.SetProp("conf_id", "0")
+            writer.write(out)
+        writer.close()
+        with open(meta_json, "w", encoding="utf-8") as f:
+            json.dump({"ok": True, "errors": []}, f)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setenv("MATCHA_CONFORMER_WORKER_CMD", "fake_worker")
+    monkeypatch.setattr("matcha.utils.preprocessing.subprocess.run", fake_run)
+
+    mol = Chem.AddHs(Chem.MolFromSmiles("CCO"), addCoords=True)
+    AllChem.EmbedMolecule(mol, AllChem.ETKDGv3())
+    output = generate_conformer_mols_batch([mol], confs_per_mol=1, backend="auto", chunk_size=1)
+
+    assert len(output) == 1
+    assert len(output[0]) == 1
+    out_mol = output[0][0]
+    assert out_mol.GetNumConformers() == 1
+    coords = out_mol.GetConformer(0).GetPositions()
+    assert np.isfinite(coords).all()

--- a/tests/test_predicted_transforms.py
+++ b/tests/test_predicted_transforms.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from matcha.dataset.pdbbind import PDBBind
+
+
+def _make_complex(name: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        ligand=SimpleNamespace(pred_tr=None, predicted_pos=None),
+        protein=SimpleNamespace(full_protein_center=np.zeros((1, 3), dtype=np.float32)),
+        original_augm_rot=np.eye(3, dtype=np.float32),
+    )
+
+
+def _make_prediction(value: float) -> dict:
+    return {
+        "tr_pred_init": np.array([[value, value + 1, value + 2]], dtype=np.float32),
+        "full_protein_center": np.zeros((1, 3), dtype=np.float32),
+        "transformed_orig": np.array([[value, value, value]], dtype=np.float32),
+    }
+
+
+def test_set_predicted_ligand_transforms_skips_empty_prediction_lists(tmp_path):
+    dataset = PDBBind.__new__(PDBBind)
+    dataset.complexes = [
+        _make_complex("ligand_a"),
+        _make_complex("ligand_b"),
+        _make_complex("ligand_c"),
+    ]
+    dataset.use_predicted_tr_only = True
+
+    predictions = {
+        "ligand_a": [_make_prediction(1.0), _make_prediction(2.0)],
+        "ligand_b": [],
+        "ligand_c": [_make_prediction(3.0)],
+    }
+    predictions_path = tmp_path / "stage2_any_conf.npy"
+    np.save(predictions_path, [predictions], allow_pickle=True)
+
+    dataset._set_predicted_ligand_transforms(str(predictions_path), n_preds_to_use=2)
+
+    assert [complex.name for complex in dataset.complexes] == [
+        "ligand_a",
+        "ligand_a",
+        "ligand_c",
+    ]
+    pred_tr_values = [complex.ligand.pred_tr.flatten().tolist() for complex in dataset.complexes]
+    assert pred_tr_values == [
+        [1.0, 2.0, 3.0],
+        [2.0, 3.0, 4.0],
+        [3.0, 4.0, 5.0],
+    ]


### PR DESCRIPTION
Supersedes #23.

## What
- add isolated nvMolKit worker backend for conformer generation
- auto-bootstrap `.venv-nvmolkit-worker` in auto mode when worker is missing
- keep CPU/RDKit fallback when worker setup or execution is unavailable

## Main changes
- `matcha/utils/preprocessing.py`
  - add worker-backed conformer generation path
  - add one-time auto-setup for worker env in `auto` backend mode
  - preserve fallback to RDKit when worker is unavailable or returns invalid output
- `scripts/setup_nvmolkit_worker.py`
  - create `.venv-nvmolkit-worker`
  - install worker package and nvMolKit prerequisites
- `packages/matcha_nvmolkit_worker/...`
  - isolated worker package and CLI entrypoint
- tests
  - worker contract test coverage
  - batch/in-memory conformer generation tests

## Why
This PR keeps the nvMolKit integration isolated from the main inference/scoring logic. Matcha can use a prepared GPU conformer worker when available, but still degrades safely to RDKit.

## Validation
```bash
uv run pytest -n0 tests/test_conformer_generation_batch.py tests/test_conformer_generation_in_memory.py tests/test_conformer_worker_contract.py
```

Optional worker setup check:
```bash
uv run python scripts/setup_nvmolkit_worker.py --skip-smoke
```