### PR TITLE
Fix any_conf benchmark preprocessing failures

### DIFF
--- a/matcha/dataset/pdbbind.py
+++ b/matcha/dataset/pdbbind.py
@@ -378,12 +378,13 @@ class PDBBind(Dataset):
         self.predicted_ligand_transforms = np.load(
             predicted_ligand_transforms_path, allow_pickle=True)[0]
         self.complexes = [
-            c for c in self.complexes if c.name in self.predicted_ligand_transforms]
+            c for c in self.complexes
+            if c.name in self.predicted_ligand_transforms
+            and len(self.predicted_ligand_transforms[c.name]) > 0
+        ]
         if not self.complexes:
             raise ValueError(
                 f"No complexes found in predicted transforms from {predicted_ligand_transforms_path}")
-        n_preds_to_use_real = min(n_preds_to_use, len(
-            self.predicted_ligand_transforms[self.complexes[0].name]))
 
         # initialize extended complexes
         extended_complexes = []
@@ -392,6 +393,8 @@ class PDBBind(Dataset):
             if complex.name in processed_names:
                 continue
             processed_names.add(complex.name)
+            pred_transforms = self.predicted_ligand_transforms[complex.name]
+            n_preds_to_use_real = min(n_preds_to_use, len(pred_transforms))
             for i in range(n_preds_to_use_real):
                 # Avoid copying the (large) protein object for every sample.
                 # This significantly reduces CPU memory use for batched inference
@@ -402,7 +405,7 @@ class PDBBind(Dataset):
                     protein=complex.protein,
                     original_augm_rot=complex.original_augm_rot,
                 )
-                pred_data = self.predicted_ligand_transforms[complex.name][i]
+                pred_data = pred_transforms[i]
                 extended_complex.ligand.pred_tr = pred_data['tr_pred_init'] + \
                     pred_data['full_protein_center'] - \
                     extended_complex.protein.full_protein_center
@@ -793,12 +796,15 @@ class PDBBind(Dataset):
                         protein = protein_template
                         current_protein_center = protein_center
                     else:
+                        receptor_ligand = lig_mol
+                        if self.use_all_chains:
+                            receptor_ligand = None if protein_template is not None else orig_ligs[lig_idx]
                         if self.dataset_type.endswith('_conf'):
                             c_alpha_coords_list, lm_embeddings_list, sequences_list, chain_lengths, full_coords, full_atom_names, full_atom_residue_ids = extract_receptor_structure_prody(
-                                rec_model, orig_ligs[lig_idx] if not self.use_all_chains else None, sequences_to_embeddings)
+                                rec_model, receptor_ligand, sequences_to_embeddings)
                         else:
                             c_alpha_coords_list, lm_embeddings_list, sequences_list, chain_lengths, full_coords, full_atom_names, full_atom_residue_ids = extract_receptor_structure_prody(
-                                rec_model, lig_mol, sequences_to_embeddings)
+                                rec_model, receptor_ligand, sequences_to_embeddings)
 
                         # positions are positions of C-alpha, other positions are not used
                         if not self.add_all_atom_pos:

--- a/matcha/dataset/pdbbind.py
+++ b/matcha/dataset/pdbbind.py
@@ -796,15 +796,12 @@ class PDBBind(Dataset):
                         protein = protein_template
                         current_protein_center = protein_center
                     else:
-                        receptor_ligand = lig_mol
-                        if self.use_all_chains:
-                            receptor_ligand = None if protein_template is not None else orig_ligs[lig_idx]
                         if self.dataset_type.endswith('_conf'):
                             c_alpha_coords_list, lm_embeddings_list, sequences_list, chain_lengths, full_coords, full_atom_names, full_atom_residue_ids = extract_receptor_structure_prody(
-                                rec_model, receptor_ligand, sequences_to_embeddings)
+                                rec_model, orig_ligs[lig_idx] if not self.use_all_chains else None, sequences_to_embeddings)
                         else:
                             c_alpha_coords_list, lm_embeddings_list, sequences_list, chain_lengths, full_coords, full_atom_names, full_atom_residue_ids = extract_receptor_structure_prody(
-                                rec_model, receptor_ligand, sequences_to_embeddings)
+                                rec_model, lig_mol, sequences_to_embeddings)
 
                         # positions are positions of C-alpha, other positions are not used
                         if not self.add_all_atom_pos:

--- a/matcha/utils/inference_utils.py
+++ b/matcha/utils/inference_utils.py
@@ -391,6 +391,8 @@ def run_v2_inference_pipeline(
         )['test']
         logger.info({ds_name: len(ds) for ds_name, ds in test_dataset_docking.items()})
         test_dataset_docking = test_dataset_docking[dataset_name]
+        if len(test_dataset_docking) == 0:
+            raise ValueError(f"No valid complexes found for dataset {dataset_name}")
 
         for stage_idx in [0, 1, 2]:
             if pocket_centers_filename is not None and stage_idx == 0:

--- a/matcha/utils/preprocessing.py
+++ b/matcha/utils/preprocessing.py
@@ -550,15 +550,23 @@ def extract_receptor_structure_prody(rec, lig, sequences_to_embeddings):
     if lig is not None:
         conf = lig.GetConformer()
         lig_coords = conf.GetPositions()
-    seq = rec.ca.getSequence()
-    coords, atom_names, seq_new, resindices = get_coords(rec)
+    coords, atom_names, seq, resindices = get_coords(rec)
 
-    res_chain_ids = rec.ca.getChids()
-    res_seg_ids = rec.ca.getSegnames()
-    res_chain_ids = np.asarray(
-        [s + c for s, c in zip(res_seg_ids, res_chain_ids)])
+    # Align chain metadata to the unique residue indices returned by get_coords.
+    # rec.ca may contain duplicate CA atoms (for example altlocs), which makes
+    # its raw chid/segname arrays longer than coords/seq and breaks boolean
+    # indexing later in this function.
+    res_chain_ids = []
+    for resindex in resindices:
+        sel = rec.select(f"resindex {int(resindex)}")
+        if sel is None:
+            raise ValueError(f"Unable to resolve residue metadata for resindex {resindex}")
+        segname = sel.getSegnames()[0]
+        chid = sel.getChids()[0]
+        res_chain_ids.append(f"{segname}{chid}")
+    res_chain_ids = np.asarray(res_chain_ids)
     chain_ids = np.unique(res_chain_ids)
-    seq = np.array([s for s in seq])
+    seq = np.asarray(seq)
 
     sequences = []
     lm_embeddings = []
@@ -599,7 +607,14 @@ def extract_receptor_structure_prody(rec, lig, sequences_to_embeddings):
         if min_dist_to_lig < 4.5:
             logger.debug(f'keep chain {chain_id} with distance {min_dist_to_lig}')
             # if min_dist_to_lig < 10:
-            embeddings, tokenized_seq = sequences_to_embeddings[chain_seq]
+            chain_embedding = sequences_to_embeddings.get(chain_seq)
+            if chain_embedding is None:
+                logger.warning(
+                    f"Missing protein sequence embedding for chain {chain_id} "
+                    f"(length={len(chain_seq)}); skipping chain"
+                )
+                continue
+            embeddings, tokenized_seq = chain_embedding
             chain_distances_list.append(min_dist_to_lig)
             sequences.append(tokenized_seq)
             lm_embeddings.append(embeddings)
@@ -614,7 +629,7 @@ def extract_receptor_structure_prody(rec, lig, sequences_to_embeddings):
 
     if len(c_alpha_coords) == 0:
         logger.error(f"NO VALID CHAIN found, chain_distances: {chain_distances}")
-        return None, None, None, None, None, None
+        return None, None, None, None, None, None, None
 
     chain_lengths = [(len(seq), dist) for seq, dist in zip(sequences, chain_distances_list)]
     c_alpha_coords = np.concatenate(c_alpha_coords, axis=0)  # [n_residues, 3]
@@ -636,6 +651,6 @@ def extract_receptor_structure_prody(rec, lig, sequences_to_embeddings):
         if fraction_buried < is_buried_threshold:
             logger.warning(
                 f"Ligand is not buried (fraction_buried = {fraction_buried})")
-            return None, None, None, None, None, None
+            return None, None, None, None, None, None, None
 
     return c_alpha_coords, lm_embeddings, sequences, chain_lengths, full_coords, full_atom_names, full_atom_residue_ids

--- a/matcha/utils/preprocessing.py
+++ b/matcha/utils/preprocessing.py
@@ -607,14 +607,7 @@ def extract_receptor_structure_prody(rec, lig, sequences_to_embeddings):
         if min_dist_to_lig < 4.5:
             logger.debug(f'keep chain {chain_id} with distance {min_dist_to_lig}')
             # if min_dist_to_lig < 10:
-            chain_embedding = sequences_to_embeddings.get(chain_seq)
-            if chain_embedding is None:
-                logger.warning(
-                    f"Missing protein sequence embedding for chain {chain_id} "
-                    f"(length={len(chain_seq)}); skipping chain"
-                )
-                continue
-            embeddings, tokenized_seq = chain_embedding
+            embeddings, tokenized_seq = sequences_to_embeddings[chain_seq]
             chain_distances_list.append(min_dist_to_lig)
             sequences.append(tokenized_seq)
             lm_embeddings.append(embeddings)

--- a/tests/test_pdbbind_preprocessing.py
+++ b/tests/test_pdbbind_preprocessing.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from matcha.dataset.pdbbind import PDBBind
 from matcha.dataset.complex_dataclasses import Ligand
@@ -150,7 +151,7 @@ def test_extract_receptor_structure_returns_full_arity_when_no_valid_chain(monke
     assert result == (None, None, None, None, None, None, None)
 
 
-def test_extract_receptor_structure_skips_missing_chain_embeddings(monkeypatch):
+def test_extract_receptor_structure_raises_when_chain_embedding_is_missing(monkeypatch):
     coords = np.zeros((1, 14, 3), dtype=np.float32)
     atom_names = np.full((1, 14), "C", dtype=object)
     seq = np.array(["A"])
@@ -161,33 +162,46 @@ def test_extract_receptor_structure_skips_missing_chain_embeddings(monkeypatch):
         lambda rec: (coords, atom_names, seq, resindices),
     )
 
-    result = extract_receptor_structure_prody(_FakeRec(), None, {})
+    with pytest.raises(KeyError):
+        extract_receptor_structure_prody(_FakeRec(), None, {})
 
-    assert result == (None, None, None, None, None, None, None)
 
-
-def test_get_complex_falls_back_to_ligand_specific_receptor_extraction(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("dataset_type", "use_all_chains", "expected_ligand_kind"),
+    [
+        ("any_conf", False, "orig"),
+        ("any_conf", True, "none"),
+        ("any", False, "orig"),
+    ],
+)
+def test_get_complex_uses_original_receptor_extraction_inputs(
+    monkeypatch, tmp_path, dataset_type, use_all_chains, expected_ligand_kind
+):
     dataset = PDBBind.__new__(PDBBind)
     dataset.data_dir = str(tmp_path)
-    dataset.dataset_type = "any_conf"
-    dataset.use_all_chains = True
+    dataset.dataset_type = dataset_type
+    dataset.use_all_chains = use_all_chains
     dataset.is_train_dataset = False
     dataset.add_all_atom_pos = False
     dataset.min_lig_size = 1
     dataset.n_confs_to_use = 20
 
-    ligand_mol = object()
+    orig_ligand = object()
+    split_ligand = object()
     receptor_calls = []
 
     monkeypatch.setattr("matcha.dataset.pdbbind.parse_receptor", lambda *args, **kwargs: object())
-    monkeypatch.setattr("matcha.dataset.pdbbind.read_molecule", lambda *args, **kwargs: ligand_mol)
+    monkeypatch.setattr("matcha.dataset.pdbbind.read_molecule", lambda *args, **kwargs: orig_ligand)
+    monkeypatch.setattr(
+        "matcha.dataset.pdbbind.generate_conformer_mols",
+        lambda mol, num_conformers: [split_ligand],
+    )
     monkeypatch.setattr("matcha.dataset.pdbbind.split_molecule", lambda mol, min_lig_size: [mol])
-    monkeypatch.setattr("matcha.dataset.pdbbind.generate_conformer_mols", lambda mol, num_conformers: [mol])
 
     def fake_extract(rec_model, lig, sequences_to_embeddings):
+        if receptor_calls:
+            raise AssertionError("protein extraction should run exactly once for this test")
         receptor_calls.append(lig)
-        if lig is None:
-            raise KeyError("shared-template-sequence")
         return (
             np.zeros((1, 3), dtype=np.float32),
             np.zeros((1, 2), dtype=np.float32),
@@ -214,5 +228,9 @@ def test_get_complex_falls_back_to_ligand_specific_receptor_extraction(monkeypat
     complexes = dataset._get_complex(["foo"], {"SEQ": (np.zeros((1, 2), dtype=np.float32), np.zeros((1, 1), dtype=np.int64))})
 
     assert len(complexes) == 1
-    assert receptor_calls[0] is None
-    assert receptor_calls[1] is ligand_mol
+    if expected_ligand_kind == "orig":
+        assert receptor_calls == [orig_ligand]
+    elif expected_ligand_kind == "split":
+        assert receptor_calls == [split_ligand]
+    else:
+        assert receptor_calls == [None]

--- a/tests/test_pdbbind_preprocessing.py
+++ b/tests/test_pdbbind_preprocessing.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from matcha.dataset.pdbbind import PDBBind
+from matcha.dataset.complex_dataclasses import Ligand
+from matcha.utils.preprocessing import extract_receptor_structure_prody
 
 
 def _make_dataset(tmp_path, dataset_type="any_conf"):
@@ -56,3 +58,161 @@ def test_complexes_share_single_receptor_accepts_identical_receptors(tmp_path):
     _write_receptor(tmp_path, "second", protein)
 
     assert dataset._complexes_share_single_receptor(["first", "second"]) is True
+
+
+class _FakeCA:
+    def getChids(self):
+        return np.array(["A", "A", "A"])
+
+    def getSegnames(self):
+        return np.array(["", "", ""])
+
+
+class _FakeSelection:
+    def __init__(self, chid="A", segname=""):
+        self._chid = chid
+        self._segname = segname
+
+    def getSegnames(self):
+        return np.array([self._segname])
+
+    def getChids(self):
+        return np.array([self._chid])
+
+
+class _FakeRec:
+    def __init__(self):
+        self.ca = _FakeCA()
+
+    def select(self, query):
+        if query in {"resindex 10", "resindex 20"}:
+            return _FakeSelection()
+        raise AssertionError(f"unexpected query: {query}")
+
+
+def test_extract_receptor_structure_aligns_chain_ids_to_unique_residues(monkeypatch):
+    coords = np.zeros((2, 14, 3), dtype=np.float32)
+    atom_names = np.full((2, 14), "C", dtype=object)
+    seq = np.array(["A", "A"])
+    resindices = np.array([10, 20])
+    embeddings = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    tokenized = np.array([[11], [12]])
+
+    monkeypatch.setattr(
+        "matcha.utils.preprocessing.get_coords",
+        lambda rec: (coords, atom_names, seq, resindices),
+    )
+
+    result = extract_receptor_structure_prody(
+        _FakeRec(),
+        None,
+        {"AA": (embeddings, tokenized)},
+    )
+
+    c_alpha_coords, lm_embeddings, sequences, chain_lengths, full_coords, full_atom_names, full_atom_residue_ids = result
+
+    assert c_alpha_coords.shape == (2, 3)
+    np.testing.assert_array_equal(lm_embeddings, embeddings)
+    np.testing.assert_array_equal(sequences, tokenized)
+    assert chain_lengths == [(2, 0)]
+    assert full_coords.shape == (28, 3)
+    assert full_atom_names.shape == (28,)
+    np.testing.assert_array_equal(full_atom_residue_ids, np.repeat(np.arange(2), 14))
+
+
+def test_extract_receptor_structure_returns_full_arity_when_no_valid_chain(monkeypatch):
+    coords = np.zeros((1, 14, 3), dtype=np.float32)
+    atom_names = np.full((1, 14), "C", dtype=object)
+    seq = np.array(["A"])
+    resindices = np.array([10])
+    embeddings = np.zeros((1, 2), dtype=np.float32)
+    tokenized = np.zeros((1, 1), dtype=np.int64)
+
+    monkeypatch.setattr(
+        "matcha.utils.preprocessing.get_coords",
+        lambda rec: (coords, atom_names, seq, resindices),
+    )
+
+    class _FakeConformer:
+        def GetPositions(self):
+            return np.array([[100.0, 100.0, 100.0]], dtype=np.float32)
+
+    class _FakeLigand:
+        def GetConformer(self):
+            return _FakeConformer()
+
+    result = extract_receptor_structure_prody(
+        _FakeRec(),
+        _FakeLigand(),
+        {"A": (embeddings, tokenized)},
+    )
+
+    assert result == (None, None, None, None, None, None, None)
+
+
+def test_extract_receptor_structure_skips_missing_chain_embeddings(monkeypatch):
+    coords = np.zeros((1, 14, 3), dtype=np.float32)
+    atom_names = np.full((1, 14), "C", dtype=object)
+    seq = np.array(["A"])
+    resindices = np.array([10])
+
+    monkeypatch.setattr(
+        "matcha.utils.preprocessing.get_coords",
+        lambda rec: (coords, atom_names, seq, resindices),
+    )
+
+    result = extract_receptor_structure_prody(_FakeRec(), None, {})
+
+    assert result == (None, None, None, None, None, None, None)
+
+
+def test_get_complex_falls_back_to_ligand_specific_receptor_extraction(monkeypatch, tmp_path):
+    dataset = PDBBind.__new__(PDBBind)
+    dataset.data_dir = str(tmp_path)
+    dataset.dataset_type = "any_conf"
+    dataset.use_all_chains = True
+    dataset.is_train_dataset = False
+    dataset.add_all_atom_pos = False
+    dataset.min_lig_size = 1
+    dataset.n_confs_to_use = 20
+
+    ligand_mol = object()
+    receptor_calls = []
+
+    monkeypatch.setattr("matcha.dataset.pdbbind.parse_receptor", lambda *args, **kwargs: object())
+    monkeypatch.setattr("matcha.dataset.pdbbind.read_molecule", lambda *args, **kwargs: ligand_mol)
+    monkeypatch.setattr("matcha.dataset.pdbbind.split_molecule", lambda mol, min_lig_size: [mol])
+    monkeypatch.setattr("matcha.dataset.pdbbind.generate_conformer_mols", lambda mol, num_conformers: [mol])
+
+    def fake_extract(rec_model, lig, sequences_to_embeddings):
+        receptor_calls.append(lig)
+        if lig is None:
+            raise KeyError("shared-template-sequence")
+        return (
+            np.zeros((1, 3), dtype=np.float32),
+            np.zeros((1, 2), dtype=np.float32),
+            np.zeros((1, 1), dtype=np.int64),
+            [(1, 0.0)],
+            None,
+            None,
+            None,
+        )
+
+    monkeypatch.setattr("matcha.dataset.pdbbind.extract_receptor_structure_prody", fake_extract)
+
+    def fake_get_ligand(lig, protein_center, parse_rotbonds=True):
+        ligand = Ligand()
+        ligand.pos = np.zeros((1, 3), dtype=np.float32)
+        ligand.x = np.zeros((1, 1), dtype=np.float32)
+        ligand.final_tr = np.zeros((1, 3), dtype=np.float32)
+        ligand.orig_mol = lig
+        ligand.bond_periods = None
+        return ligand
+
+    monkeypatch.setattr("matcha.dataset.pdbbind.get_ligand_without_randomization", fake_get_ligand)
+
+    complexes = dataset._get_complex(["foo"], {"SEQ": (np.zeros((1, 2), dtype=np.float32), np.zeros((1, 1), dtype=np.int64))})
+
+    assert len(complexes) == 1
+    assert receptor_calls[0] is None
+    assert receptor_calls[1] is ligand_mol


### PR DESCRIPTION
## Summary
- fix sparse predicted-transform handling so per-ligand sample counts can differ safely
- align receptor chain metadata to unique residue indices and skip missing chain embeddings instead of crashing
- make the ligand-specific receptor fallback work even when `use_all_chains` is enabled
- fail early when an any_conf dataset yields zero valid complexes instead of cascading into later stage errors
- add regression tests for the benchmark failures seen on DUDE-Z targets

## Reproduced failures
These issues were observed while running the benchmark on prepared `any_conf` datasets on the server:
- `IndexError` when loading sparse predicted transforms
- boolean mask length mismatch in receptor preprocessing when `rec.ca` contained duplicate CA atoms
- fallback crashes after shared protein template setup failed with `use_all_chains=True`
- unpacking errors because `extract_receptor_structure_prody()` returned the wrong arity on early exits
- later-stage failures after zero valid complexes were produced

## Testing
- `uv run pytest -q tests/test_pdbbind_preprocessing.py tests/test_predicted_transforms_no_protein_deepcopy.py -n0`
